### PR TITLE
Add retained-watch support to lua-bus

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,43 +2,52 @@
 
 ## Overview
 
-The `bus` module provides an in-process pub/sub messaging bus built on `fibers` and a trie-based topic matcher.
+The `bus` module provides an in-process messaging bus built on `fibers` and trie-based topic matching.
 
 It is intended for cooperative, single-threaded systems running under `fibers.run(...)`, where:
 
-* delivery is **bounded** (every subscription has a bounded queue, possibly zero-length), and
-* publishing is **non-blocking** (publish never blocks; slow consumers do not stall publishers).
+* delivery is **bounded** (every subscription, endpoint, and retained watch has a bounded queue, possibly zero-length), and
+* publishing and routing are **non-blocking** (slow consumers do not stall publishers).
 
-The bus uses two tries:
+The bus uses three tries:
 
-* a **pubsub trie** for wildcard subscriptions (wildcards allowed in stored keys; queries are literal), and
-* a **retained trie** for retained state (stored keys are literal; wildcards allowed in queries).
+* a **pubsub trie** for ordinary subscriptions (wildcards allowed in stored keys; queries are literal),
+* a **retained trie** for retained state (stored keys are literal; wildcards allowed in queries), and
+* a **retained-watch trie** for observing retained-state lifecycle events (wildcards allowed in stored keys; queries are literal).
 
 ## Key ideas
 
-* **Bus**: the shared router and retained store.
-* **Connection**: the publishing/subscription capability you pass to services; scope-bound by default.
-* **Subscription**: a per-subscriber mailbox; exposes `Op`-based message retrieval.
-* **Message**: `{ topic, payload, reply_to?, id? }` delivered to subscribers.
+* **Bus**: the shared router, retained store, endpoint registry, and retained-watch registry.
+* **Connection**: the capability you pass to services; scope-bound by default.
+* **Subscription**: a per-subscriber mailbox for ordinary publish fanout.
+* **RetainedWatch**: a per-watcher mailbox for retained-state lifecycle events.
+* **Endpoint**: a concrete point-to-point mailbox for lane B delivery.
+* **Message**: `{ topic, payload, reply_to?, id? }` delivered to subscriptions and endpoints.
+* **RetainedEvent**: `{ op, topic, payload?, reply_to?, id? }` delivered to retained watches.
 
 ## Assumptions and semantics
 
 * Use only **inside fibers** (from within `fibers.run(...)`).
-* Publishing is **best-effort fanout**:
+* Ordinary publish fanout is **best-effort**:
 
-  * the bus attempts a single non-blocking enqueue per subscription,
+  * the bus attempts a single non-blocking enqueue per matching subscription,
   * if enqueue would block or is rejected by policy, the message is dropped for that subscription.
+* Retained-watch delivery is also **best-effort** and bounded:
+
+  * retained writes and retained removals are turned into retained events,
+  * the bus attempts a single non-blocking enqueue per matching retained watch,
+  * if enqueue would block or is rejected by policy, the event is dropped for that watch.
 * Timeouts are not built in; compose them externally using `fibers.named_choice` / `fibers.choice` plus `fibers.sleep.sleep_op`.
 
 ## Topics, wildcards, and literals
 
-Topics are token arrays (dense tables indexed `1..n`), e.g.
+Topics are token arrays (dense tables indexed `1..n`), for example:
 
 ```lua
 { 'net', 'link' }
-```
+````
 
-Wildcards are supported in subscription patterns:
+Wildcards are supported in subscription and retained-watch patterns:
 
 * single-level wildcard token: `+` (configurable via `s_wild`)
 * multi-level wildcard token: `#` (configurable via `m_wild`)
@@ -53,41 +62,104 @@ local Bus = require 'bus'
 local topic = { 'cfg', Bus.literal('+') }  -- matches the literal "+" token
 ```
 
-A literal token is treated as concrete for endpoint binding and request/reply topics.
+A literal token is treated as concrete for endpoint binding, point-to-point routing, and request/reply topics.
 
 ## Delivery, queues, and full policy
 
-Each subscription has:
+Each subscription, retained watch, and endpoint mailbox has:
 
 * `queue_len` (number, **≥ 0**)
 * `full` policy:
 
   * `"drop_oldest"` (default)
   * `"reject_newest"`
-  * `"block"` is rejected (this bus must remain bounded and non-blocking)
+  * `"block"` is rejected (the bus must remain bounded and non-blocking)
 
 `"drop_newest"` is deprecated and not supported; use `"reject_newest"`.
 
-### Queue length = 0 (rendezvous subscriptions)
+### Queue length = 0
 
-A `queue_len` of `0` creates a rendezvous-style subscription:
+A `queue_len` of `0` creates a rendezvous-style mailbox:
 
-* delivery succeeds only if a receiver is waiting at publish time,
-* otherwise delivery would block, so the bus drops (or rejects) the message.
+* delivery succeeds only if a receiver is waiting at send time,
+* otherwise delivery would block, so the bus drops (or rejects) the item.
 
-This is useful for “only if someone is listening right now” topics.
+For subscriptions and retained watches, this is useful when you only want delivery if someone is actively waiting.
 
 ### Drop accounting
 
-Drops are tracked per-subscription and can be queried:
+Drops are tracked per handle and can be queried:
 
 * `sub:dropped()` — drops for that subscription
-* `conn:dropped()` — sum of drops across subscriptions owned by the connection (computed at query time)
+* `watch:dropped()` — drops for that retained watch
+* `ep:dropped()` — drops for that endpoint
+* `conn:dropped()` — sum of drops across owned subscriptions, retained watches, and endpoints
 
 The counter aggregates both:
 
 * buffered evictions under `"drop_oldest"`, and
 * rejections under `"reject_newest"`.
+
+## Retained state and retained watches
+
+Retained messages are stored under concrete topics and replayed to future matching subscriptions.
+
+A retained write:
+
+```lua
+conn:retain({ 'fw', 'version' }, '1.2.3')
+```
+
+does two things:
+
+1. it publishes the message to ordinary subscribers, and
+2. it stores the retained value for future replay.
+
+A retained removal:
+
+```lua
+conn:unretain({ 'fw', 'version' })
+```
+
+removes the retained value. It does **not** publish an ordinary message.
+
+### Watching retained-state lifecycle
+
+If you need to observe retained writes and removals as events, use `watch_retained(...)`.
+
+A retained watch receives `RetainedEvent` records:
+
+* on retain:
+
+  ```lua
+  {
+    op       = 'retain',
+    topic    = ...,
+    payload  = ...,
+    reply_to = ...,
+    id       = ...,
+  }
+  ```
+
+* on unretain:
+
+  ```lua
+  {
+    op    = 'unretain',
+    topic = ...,
+  }
+  ```
+
+Retained watches are independent of ordinary subscriptions.
+
+### Replay on watch creation
+
+`watch_retained(...)` accepts `replay = true` to emit synthetic `retain` events for the current retained items that match the pattern.
+
+This is useful for consumers that need both:
+
+* the current retained image, and
+* subsequent retained changes.
 
 ## Installation
 
@@ -108,9 +180,21 @@ local Bus = require 'bus'
 ### Bus
 
 * `Bus.new(params?) -> bus`
-* `bus:connect() -> conn`
+* `bus:connect([opts]) -> conn`
 * `bus:stats() -> table`
 * `Bus.literal(v) -> literal_token` (or `require('bus').literal(v)`)
+
+Constructor parameters:
+
+* `q_length?: integer`
+* `full?: "drop_oldest"|"reject_newest"`
+* `s_wild?: string|number`
+* `m_wild?: string|number`
+* `authoriser?: function|table`
+
+`bus:connect(opts?)` currently accepts:
+
+* `principal?: any`
 
 ### Connection
 
@@ -119,8 +203,11 @@ local Bus = require 'bus'
 * `conn:unretain(topic) -> true`
 * `conn:subscribe(topic[, opts]) -> sub`
 * `conn:unsubscribe(sub) -> true`
+* `conn:watch_retained(topic[, opts]) -> watch`
+* `conn:unwatch_retained(watch) -> true`
 * `conn:disconnect() -> true`
 * `conn:is_disconnected() -> boolean`
+* `conn:principal() -> any|nil`
 * `conn:dropped() -> number`
 * `conn:stats() -> table`
 * `conn:request_sub(topic, payload[, opts]) -> sub`
@@ -147,6 +234,17 @@ Lane B (opt-in):
 * `sub:topic() -> Topic`
 * `sub:stats() -> table`
 
+### RetainedWatch
+
+* `watch:recv_op() -> Op` yielding `(RetainedEvent|nil, err|string|nil)`
+* `watch:recv() -> RetainedEvent|nil, err|string|nil`
+* `watch:unwatch() -> true`
+* `watch:iter() -> iterator<RetainedEvent>`
+* `watch:why() -> any|nil`
+* `watch:dropped() -> number`
+* `watch:topic() -> Topic`
+* `watch:stats() -> table`
+
 ### Endpoint (lane B)
 
 * `ep:recv_op() -> Op` yielding `(Message|nil, err|string|nil)`
@@ -166,10 +264,18 @@ Lane B (opt-in):
 local Bus = require 'bus'
 
 local bus = Bus.new{
-  q_length = 10,            -- default queue length for subscriptions
+  q_length = 10,            -- default queue length
   full     = 'drop_oldest', -- default full policy
   s_wild   = '+',
   m_wild   = '#',
+}
+```
+
+With authorisation:
+
+```lua
+local bus = Bus.new{
+  authoriser = my_authoriser,
 }
 ```
 
@@ -179,6 +285,14 @@ local bus = Bus.new{
 
 ```lua
 local conn = bus:connect()
+```
+
+With a principal:
+
+```lua
+local conn = bus:connect{
+  principal = my_principal,
+}
 ```
 
 ### Publish
@@ -191,7 +305,7 @@ Publishing never blocks. If a subscriber cannot accept immediately, that subscri
 
 ### Retain and unretain
 
-Retained messages are stored and replayed to matching future subscriptions (best-effort, bounded):
+Retained messages are stored and replayed to matching future subscriptions:
 
 ```lua
 conn:retain({ 'fw', 'version' }, '1.2.3')
@@ -217,13 +331,13 @@ Override queue length and policy:
 local sub = conn:subscribe({ 'net', '+' }, { queue_len = 50, full = 'reject_newest' })
 ```
 
-Rendezvous subscription (bounded, non-blocking):
+Rendezvous subscription:
 
 ```lua
 local sub = conn:subscribe({ 'events', 'transient' }, { queue_len = 0, full = 'reject_newest' })
 ```
 
-### Receive (sync) and compose a timeout (recommended)
+### Receive (sync) and compose a timeout
 
 `recv()` blocks until a message arrives or the subscription closes:
 
@@ -255,11 +369,58 @@ else
 end
 ```
 
-### Unsubscribe and disconnect
+### Watch retained-state changes
+
+Create a retained watch:
 
 ```lua
-sub:unsubscribe()   -- idempotent, wakes waiters
-conn:disconnect()   -- idempotent, closes all owned subs/endpoints
+local watch = conn:watch_retained({ 'config', '#' }, {
+  queue_len = 16,
+  full      = 'drop_oldest',
+  replay    = true,
+})
+```
+
+Consume retained events:
+
+```lua
+local ev, err = watch:recv()
+if ev then
+  if ev.op == 'retain' then
+    print('retained update:', ev.payload)
+  elseif ev.op == 'unretain' then
+    print('retained removal:', table.concat(ev.topic, '/'))
+  end
+else
+  print('watch closed:', err)
+end
+```
+
+Compose with a timeout:
+
+```lua
+local fibers = require 'fibers'
+local sleep  = require 'fibers.sleep'
+
+local evsel = fibers.named_choice{
+  event    = watch:recv_op(),
+  deadline = sleep.sleep_op(1.0),
+}
+
+local which, ev, err = fibers.perform(evsel)
+if which == 'event' then
+  -- ev may be nil if the watch closed
+else
+  -- deadline fired
+end
+```
+
+### Unsubscribe, unwatch, and disconnect
+
+```lua
+sub:unsubscribe()     -- idempotent, wakes waiters
+watch:unwatch()       -- idempotent, wakes waiters
+conn:disconnect()     -- idempotent, closes all owned subs/watches/endpoints
 ```
 
 ## Request/reply
@@ -301,8 +462,97 @@ else
 end
 ```
 
+## Lane B: concrete point-to-point delivery
+
+Lane B is opt-in and separate from ordinary pub/sub.
+
+Use it when you want:
+
+* exactly one concrete destination topic,
+* bounded admission signalling,
+* explicit request/reply style interactions.
+
+Bind a concrete endpoint:
+
+```lua
+local ep = conn:bind({ 'rpc', 'echo' }, { queue_len = 1 })
+```
+
+Deliver to it directly:
+
+```lua
+local ok, reason = conn:publish_one({ 'rpc', 'echo' }, 'hello')
+```
+
+Point-to-point topics must be concrete. Wildcards are rejected, though literal wildcard tokens are allowed via `Bus.literal(...)`.
+
+## Authorisation
+
+The bus can be constructed with an optional `authoriser`.
+
+Supported forms are:
+
+* `function(ctx) -> boolean|nil, reason?`
+* table with `:allow(ctx)`
+* table with `:authorize(ctx)`
+
+The authoriser is called with a context like:
+
+```lua
+{
+  bus       = bus,
+  principal = principal,
+  action    = action,
+  topic     = topic,
+  extra     = extra,
+}
+```
+
+Current actions include:
+
+* `publish`
+* `retain`
+* `unretain`
+* `subscribe`
+* `watch_retained`
+* `bind`
+* `publish_one`
+* `request`
+* `call`
+
+If authorisation fails, the operation raises an error.
+
+## Stats
+
+`conn:stats()` returns:
+
+```lua
+{
+  dropped          = ...,
+  subscriptions    = ...,
+  endpoints        = ...,
+  retained_watches = ...,
+}
+```
+
+`bus:stats()` returns:
+
+```lua
+{
+  connections      = ...,
+  dropped          = ...,
+  queue_len        = ...,
+  full_policy      = ...,
+  s_wild           = ...,
+  m_wild           = ...,
+  retained_watches = ...,
+}
+```
+
 ## Notes and limitations
 
 * Delivery is best-effort; drops are expected under overload.
-* Retained replay is also best-effort and bounded (a new subscription may drop retained replays if it cannot accept immediately).
+* Retained replay to new subscriptions is best-effort and bounded.
+* Retained-watch replay and live retained events are also best-effort and bounded.
 * `full = "block"` is intentionally not supported by the bus.
+* Ordinary subscriptions observe published messages; retained watches observe retained-state lifecycle. They are related, but not the same mechanism.

--- a/src/bus.lua
+++ b/src/bus.lua
@@ -3,6 +3,7 @@
 -- In-process pub/sub bus built on fibers + trie.
 --  - wildcard subscriptions (pubsub trie: wildcards allowed in stored keys; literal queries)
 --  - retained messages (retained trie: literal stored keys; wildcards allowed in queries)
+--  - retained watch feeds (wildcard watch patterns over retain/unretain lifecycle)
 --  - request/response helpers (reply_to topic)
 --
 -- Optional extensions:
@@ -32,10 +33,6 @@ local DEFAULT_POLICY = 'drop_oldest'
 -- trie literal helper (escape hatch)
 --------------------------------------------------------------------------------
 
--- Latest trie supports trie.literal(v) to force literal matching even when v equals
--- the wildcard symbols (e.g. "+" or "#"). To interoperate cleanly, the bus must:
---   * allow literal tokens in topics, and
---   * treat literal tokens as concrete (non-wild) for "concrete topic" checks.
 local LIT_MT = getmetatable(trie.literal('x'))
 
 ---@param tok any
@@ -80,7 +77,6 @@ local function assert_full_policy(p, level)
 	error('invalid mailbox full policy: ' .. tostring(p), level)
 end
 
---- Dense array validation (mirrors trie.lua behaviour).
 ---@param t any
 ---@param errlvl integer
 ---@return integer n
@@ -101,7 +97,6 @@ local function array_len(t, errlvl)
 	return n
 end
 
---- Topic validation: array elements must be strings/numbers or trie.literal(v).
 ---@param topic any
 ---@param what string
 ---@param level? integer
@@ -138,7 +133,6 @@ local function assert_concrete_topic(s_wild, m_wild, topic, what, level)
 	end
 end
 
---- Stable key for a concrete topic (within a single process).
 ---@param topic Topic
 ---@return string
 local function topic_key(topic)
@@ -172,10 +166,6 @@ end
 -- Authorisation
 --------------------------------------------------------------------------------
 
---- Resolve an authoriser callable from:
----   * function(ctx) -> boolean|nil, reason?
----   * table:allow(ctx) -> boolean|nil, reason?
----   * table:authorize(ctx) -> boolean|nil, reason?
 ---@param auth any
 ---@return function|nil
 local function authoriser_callable(auth)
@@ -256,7 +246,7 @@ local function assert_authorized(self, action, topic, extra, level)
 end
 
 --------------------------------------------------------------------------------
--- Message
+-- Message / retained events
 --------------------------------------------------------------------------------
 
 ---@class Message
@@ -279,6 +269,31 @@ local function new_msg(topic, payload, reply_to, id)
 		reply_to = reply_to,
 		id       = id,
 	}, Message)
+end
+
+---@class RetainedEvent
+---@field op '"retain"'|'"unretain"'
+---@field topic Topic
+---@field payload any|nil
+---@field reply_to Topic|nil
+---@field id any|nil
+local RetainedEvent = {}
+RetainedEvent.__index = RetainedEvent
+
+---@param op_name '"retain"'|'"unretain"'
+---@param topic Topic
+---@param payload? any
+---@param reply_to? Topic
+---@param id? any
+---@return RetainedEvent
+local function new_retained_event(op_name, topic, payload, reply_to, id)
+	return setmetatable({
+		op       = op_name,
+		topic    = topic,
+		payload  = payload,
+		reply_to = reply_to,
+		id       = id,
+	}, RetainedEvent)
 end
 
 --------------------------------------------------------------------------------
@@ -305,7 +320,6 @@ local function new_subscription(conn, topic, tx, rx)
 end
 
 function Subscription:topic() return self._topic end
-
 function Subscription:why() return self._rx:why() end
 
 function Subscription:dropped()
@@ -327,7 +341,6 @@ function Subscription:unsubscribe()
 	return conn:unsubscribe(self)
 end
 
---- recv_op: when performed -> Message|nil, err|string|nil
 ---@return Op
 function Subscription:recv_op()
 	return self._rx:recv_op():wrap(function (msg)
@@ -343,7 +356,6 @@ function Subscription:recv()
 end
 
 function Subscription:iter()
-	-- Iterator yields Message values until nil.
 	return self._rx:iter()
 end
 
@@ -356,6 +368,73 @@ function Subscription:payloads()
 end
 
 function Subscription:stats()
+	return { dropped = self:dropped(), topic = self._topic }
+end
+
+--------------------------------------------------------------------------------
+-- Retained watch feed
+--------------------------------------------------------------------------------
+
+---@class RetainedWatch
+---@field _conn Connection|nil
+---@field _topic Topic
+---@field _tx MailboxTx
+---@field _rx MailboxRx
+---@field _detach_finaliser (fun())|nil
+local RetainedWatch = {}
+RetainedWatch.__index = RetainedWatch
+
+local function new_retained_watch(conn, topic, tx, rx)
+	return setmetatable({
+		_conn             = conn,
+		_topic            = topic,
+		_tx               = tx,
+		_rx               = rx,
+		_detach_finaliser = nil,
+	}, RetainedWatch)
+end
+
+function RetainedWatch:topic() return self._topic end
+function RetainedWatch:why() return self._rx:why() end
+
+function RetainedWatch:dropped()
+	local tx = self._tx
+	return (tx and tx.dropped and tx:dropped()) or 0
+end
+
+---@param reason any
+function RetainedWatch:_close(reason)
+	if self._tx then self._tx:close(reason) end
+end
+
+function RetainedWatch:unwatch()
+	local conn = self._conn
+	if not conn then
+		self:_close('unwatched')
+		return true
+	end
+	return conn:unwatch_retained(self)
+end
+
+---@return Op
+function RetainedWatch:recv_op()
+	return self._rx:recv_op():wrap(function (ev)
+		if ev == nil then
+			return nil, tostring(self._rx:why() or 'closed')
+		end
+		return ev, nil
+	end)
+end
+
+function RetainedWatch:recv()
+	return perform(self:recv_op())
+end
+
+function RetainedWatch:iter()
+	return self._rx:iter()
+end
+
+function RetainedWatch:stats()
 	return { dropped = self:dropped(), topic = self._topic }
 end
 
@@ -385,7 +464,6 @@ local function new_endpoint(conn, topic, key, tx, rx)
 end
 
 function Endpoint:topic() return self._topic end
-
 function Endpoint:why() return self._rx:why() end
 
 function Endpoint:dropped()
@@ -437,6 +515,7 @@ end
 ---@field _full FullPolicy
 ---@field _topics any
 ---@field _retained any
+---@field _retained_watchers any
 ---@field _conns table<Connection, boolean>
 ---@field _s_wild string|number
 ---@field _m_wild string|number
@@ -445,22 +524,18 @@ end
 local Bus = {}
 Bus.__index = Bus
 
---- Best-effort delivery:
---- - never raises for congestion/closure
---- - avoids raising scope cancellation/failure by using scope:try when running
 ---@param tx MailboxTx
----@param msg Message
-local function deliver_best_effort(tx, msg)
+---@param value any
+local function deliver_best_effort(tx, value)
 	local s = scope_mod.current()
 	if s and s.try and s.status then
 		local st = select(1, s:status())
 		if st == 'running' then
-			s:try(tx:send_op(msg))
+			s:try(tx:send_op(value))
 			return
 		end
 	end
-	-- Fallback: raw perform. With non-blocking policies, this remains bounded.
-	op.perform_raw(tx:send_op(msg))
+	op.perform_raw(tx:send_op(value))
 end
 
 ---@param conn Connection
@@ -479,7 +554,6 @@ function Bus:_subscribe(conn, topic, qlen, full)
 	local sub    = new_subscription(conn, topic, tx, rx)
 	subs[sub]    = true
 
-	-- Retained replay is best-effort and bounded.
 	self._retained:each(topic, function (_k, retained_msg)
 		deliver_best_effort(tx, retained_msg)
 	end)
@@ -506,13 +580,61 @@ function Bus:_publish(msg)
 	end)
 end
 
+function Bus:_notify_retained(ev)
+	self._retained_watchers:each(ev.topic, function (_k, watchers)
+		for rw in pairs(watchers) do
+			if rw and rw._tx then
+				deliver_best_effort(rw._tx, ev)
+			end
+		end
+	end)
+end
+
 function Bus:_retain(msg)
 	self:_publish(msg)
 	self._retained:insert(msg.topic, msg)
+	self:_notify_retained(new_retained_event('retain', msg.topic, msg.payload, msg.reply_to, msg.id))
 end
 
 function Bus:_unretain(topic)
 	self._retained:delete(topic)
+	self:_notify_retained(new_retained_event('unretain', topic))
+end
+
+---@param conn Connection
+---@param topic Topic
+---@param qlen integer
+---@param full FullPolicy
+---@param replay boolean
+---@return RetainedWatch
+function Bus:_watch_retained(conn, topic, qlen, full, replay)
+	local watchers = self._retained_watchers:retrieve(topic)
+	if not watchers then
+		watchers = {}
+		self._retained_watchers:insert(topic, watchers)
+	end
+
+	local tx, rx = mailbox.new(qlen, { full = full })
+	local rw     = new_retained_watch(conn, topic, tx, rx)
+	watchers[rw] = true
+
+	if replay then
+		self._retained:each(topic, function (_k, retained_msg)
+			deliver_best_effort(tx,
+				new_retained_event('retain', retained_msg.topic, retained_msg.payload, retained_msg.reply_to, retained_msg.id))
+		end)
+	end
+
+	return rw
+end
+
+function Bus:_unwatch_retained(rw)
+	local watchers = self._retained_watchers:retrieve(rw._topic)
+	if not watchers then return end
+	watchers[rw] = nil
+	if next(watchers) == nil then
+		self._retained_watchers:delete(rw._topic)
+	end
 end
 
 --------------------------------------------------------------------------------
@@ -526,6 +648,7 @@ end
 ---@field _full FullPolicy
 ---@field _subs table<Subscription, boolean>
 ---@field _eps table<Endpoint, boolean>
+---@field _rws table<RetainedWatch, boolean>
 ---@field _disconnected boolean
 local Connection = {}
 Connection.__index = Connection
@@ -544,6 +667,7 @@ local function new_connection(bus, principal, q_length, full)
 		_full         = full,
 		_subs         = {},
 		_eps          = {},
+		_rws          = {},
 		_disconnected = false,
 	}, Connection)
 end
@@ -564,11 +688,12 @@ function Connection:dropped()
 	for ep in pairs(self._eps) do
 		n = n + (ep:dropped() or 0)
 	end
+	for rw in pairs(self._rws) do
+		n = n + (rw:dropped() or 0)
+	end
 	return n
 end
 
---- publish(topic, payload[, opts])
---- opts: { reply_to?: Topic, id?: any }
 function Connection:publish(topic, payload, opts)
 	assert_connected(self, 1)
 	assert_topic(topic, 'topic', 1)
@@ -619,8 +744,6 @@ function Connection:unretain(topic)
 	return true
 end
 
---- Internal subscribe helper with no authz check.
---- opts: { queue_len?: integer, full?: FullPolicy }
 ---@param topic Topic
 ---@param opts? table
 ---@return Subscription
@@ -649,8 +772,6 @@ function Connection:_subscribe_internal(topic, opts)
 	return sub
 end
 
---- subscribe(topic[, opts]) -> Subscription
---- opts: { queue_len?: integer, full?: FullPolicy }
 function Connection:subscribe(topic, opts)
 	assert_connected(self, 1)
 	assert_topic(topic, 'topic', 1)
@@ -684,6 +805,68 @@ function Connection:unsubscribe(sub)
 	return true
 end
 
+---@param topic Topic
+---@param opts? table
+---@return RetainedWatch
+function Connection:_watch_retained_internal(topic, opts)
+	assert_connected(self, 1)
+
+	opts = opts or {}
+	if type(opts) ~= 'table' then
+		error('_watch_retained_internal: opts must be a table (or nil)', 2)
+	end
+
+	local qlen = opts.queue_len
+	if qlen == nil then qlen = self._q_length end
+	if type(qlen) ~= 'number' or qlen < 0 then
+		error('_watch_retained_internal: queue_len must be >= 0', 2)
+	end
+
+	local fullp = assert_full_policy(opts.full or self._full, 2) or DEFAULT_POLICY
+	local replay = not not opts.replay
+
+	local rw = self._bus:_watch_retained(self, topic, qlen, fullp, replay)
+	self._rws[rw] = true
+
+	local s = scope_mod.current()
+	rw._detach_finaliser = s:finally(function () rw:unwatch() end)
+
+	return rw
+end
+
+function Connection:watch_retained(topic, opts)
+	assert_connected(self, 1)
+	assert_topic(topic, 'topic', 1)
+
+	assert_authorized(self, 'watch_retained', topic, {
+		opts = opts,
+	}, 1)
+
+	return self:_watch_retained_internal(topic, opts)
+end
+
+function Connection:unwatch_retained(rw)
+	if not rw or getmetatable(rw) ~= RetainedWatch then
+		error('unwatch_retained expects a RetainedWatch', 2)
+	end
+
+	local owned = not not self._rws[rw]
+
+	rw:_close('unwatched')
+
+	if rw._detach_finaliser then
+		rw._detach_finaliser()
+		rw._detach_finaliser = nil
+	end
+
+	if owned then
+		self._rws[rw] = nil
+		self._bus:_unwatch_retained(rw)
+	end
+	if rw._conn == self then rw._conn = nil end
+	return true
+end
+
 function Connection:disconnect()
 	if self._disconnected then return true end
 	self._disconnected = true
@@ -691,7 +874,6 @@ function Connection:disconnect()
 	local bus = self._bus
 	self._bus = nil
 
-	-- Snapshot to avoid mutation during pairs().
 	local subs = {}
 	for sub in pairs(self._subs) do subs[#subs + 1] = sub end
 	for i = 1, #subs do
@@ -705,6 +887,22 @@ function Connection:disconnect()
 			if bus then bus:_unsubscribe(sub) end
 			self._subs[sub] = nil
 			if sub._conn == self then sub._conn = nil end
+		end
+	end
+
+	local rws = {}
+	for rw in pairs(self._rws) do rws[#rws + 1] = rw end
+	for i = 1, #rws do
+		local rw = rws[i]
+		if rw then
+			rw:_close('disconnected')
+			if rw._detach_finaliser then
+				rw._detach_finaliser()
+				rw._detach_finaliser = nil
+			end
+			if bus then bus:_unwatch_retained(rw) end
+			self._rws[rw] = nil
+			if rw._conn == self then rw._conn = nil end
 		end
 	end
 
@@ -731,18 +929,22 @@ function Connection:disconnect()
 end
 
 function Connection:stats()
-	local nsubs, neps = 0, 0
+	local nsubs, neps, nrws = 0, 0, 0
 	for _ in pairs(self._subs) do nsubs = nsubs + 1 end
 	for _ in pairs(self._eps) do neps = neps + 1 end
-	return { dropped = self:dropped(), subscriptions = nsubs, endpoints = neps }
+	for _ in pairs(self._rws) do nrws = nrws + 1 end
+	return {
+		dropped         = self:dropped(),
+		subscriptions   = nsubs,
+		endpoints       = neps,
+		retained_watches = nrws,
+	}
 end
 
 --------------------------------------------------------------------------------
 -- Request helpers (lane A)
 --------------------------------------------------------------------------------
 
---- request_sub(topic, payload[, opts]) -> Subscription
---- opts: { queue_len?: integer, full?: FullPolicy }
 function Connection:request_sub(topic, payload, opts)
 	assert_connected(self, 1)
 	assert_topic(topic, 'topic', 1)
@@ -760,14 +962,11 @@ function Connection:request_sub(topic, payload, opts)
 	local reply_to = { uuid.new() }
 	local msg      = new_msg(topic, payload, reply_to)
 
-	-- Subscribe first to avoid racing a fast responder.
 	local sub = self:_subscribe_internal(reply_to, opts)
 	self._bus:_publish(msg)
 	return sub
 end
 
---- request_once_op(topic, payload[, opts]) -> Op
---- opts: { timeout?: number } is intentionally not built-in; caller composes.
 function Connection:request_once_op(topic, payload, opts)
 	opts = opts or {}
 	if type(opts) ~= 'table' then
@@ -788,7 +987,6 @@ function Connection:request_once_op(topic, payload, opts)
 
 		return op.bracket(
 			function ()
-				-- Keep the first reply; reject duplicates.
 				return self:_subscribe_internal(reply_to, { queue_len = 1, full = 'reject_newest' })
 			end,
 			function (sub) sub:unsubscribe() end,
@@ -804,8 +1002,6 @@ end
 -- Lane B: endpoints + publish_one + call_op (opt-in)
 --------------------------------------------------------------------------------
 
---- Internal bind helper with no authz check.
---- opts: { queue_len?: integer }  (full policy is fixed to reject_newest)
 ---@param topic Topic
 ---@param opts? table
 ---@return Endpoint
@@ -831,7 +1027,6 @@ function Connection:_bind_internal(topic, opts)
 		error('bind: topic is already bound', 2)
 	end
 
-	-- Endpoint mailboxes use reject_newest for explicit admission signalling.
 	local tx, rx = mailbox.new(qlen, { full = 'reject_newest' })
 	local ep     = new_endpoint(self, topic, key, tx, rx)
 
@@ -844,8 +1039,6 @@ function Connection:_bind_internal(topic, opts)
 	return ep
 end
 
---- bind(topic[, opts]) -> Endpoint
---- opts: { queue_len?: integer }  (full policy is fixed to reject_newest)
 function Connection:bind(topic, opts)
 	assert_connected(self, 1)
 	assert_topic(topic, 'topic', 1)
@@ -881,9 +1074,6 @@ function Connection:unbind(ep)
 	return true
 end
 
---- publish_one_op(topic, payload[, opts]) -> Op
---- opts: { reply_to?: Topic, id?: any }
---- when performed -> ok:boolean, reason:any|nil
 function Connection:publish_one_op(topic, payload, opts)
 	opts = opts or {}
 	if type(opts) ~= 'table' then
@@ -917,12 +1107,7 @@ function Connection:publish_one_op(topic, payload, opts)
 
 		local msg = new_msg(topic, payload, reply_to, opts.id)
 
-		-- Leaf op: do not perform inside guard.
 		return ep._tx:send_op(msg):wrap(function (ok, reason)
-			-- mailbox send semantics:
-			--   true            accepted
-			--   false, "full"   rejected
-			--   nil             closed
 			if ok == true then return true, nil end
 			if ok == nil then return false, 'closed' end
 			return false, reason or 'full'
@@ -934,9 +1119,6 @@ function Connection:publish_one(topic, payload, opts)
 	return perform(self:publish_one_op(topic, payload, opts))
 end
 
---- call_op(topic, payload[, opts]) -> Op
---- opts: { timeout?: number, deadline?: number, backoff?: number, backoff_max?: number, request_id?: any }
---- when performed -> reply_payload|nil, err|string|nil
 function Connection:call_op(topic, payload, opts)
 	opts = opts or {}
 	if type(opts) ~= 'table' then
@@ -963,8 +1145,6 @@ function Connection:call_op(topic, payload, opts)
 		local request_id  = (opts.request_id ~= nil) and opts.request_id or uuid.new()
 		local reply_topic = { request_id }
 
-		-- Bind reply endpoint first to avoid racing a fast responder.
-		-- Use bracket so abort/cleanup unbinds it.
 		return op.bracket(
 			function ()
 				return self:_bind_internal(reply_topic, { queue_len = 1 })
@@ -973,16 +1153,12 @@ function Connection:call_op(topic, payload, opts)
 				if rep_ep then pcall(function () rep_ep:unbind() end) end
 			end,
 			function (rep_ep)
-				-- Internal state machine (no worker fibre).
-				local phase    = 'publish' -- 'publish' -> 'wait_reply'
+				local phase    = 'publish'
 				local next_try = runtime.now()
 				local b        = backoff
 
-				-- Precompute callee route key (topic is concrete).
 				local callee_key = topic_key(topic)
 
-				-- Check whether reply mailbox already has a buffered message.
-				-- This must be observational (no popping).
 				local function reply_buffered()
 					local rx = rep_ep and rep_ep._rx
 					local st = rx and rx._st
@@ -996,8 +1172,6 @@ function Connection:call_op(topic, payload, opts)
 					return (not st) or st.closed or false
 				end
 
-				-- Attempt a single point-to-point publish without yielding.
-				-- Returns: ok:boolean, reason:any|nil
 				local function try_publish_once()
 					local ep = bus._endpoints and bus._endpoints[callee_key] or nil
 					if not ep or not ep._tx then
@@ -1006,17 +1180,10 @@ function Connection:call_op(topic, payload, opts)
 
 					local msg = new_msg(topic, payload, reply_topic, request_id)
 
-					-- Use mailbox send_op's try_fn directly (non-yielding).
 					local send_op = ep._tx:send_op(msg)
 					local r1, r2, r3 = send_op.try_fn()
 
-					-- mailbox send semantics:
-					--   ready==true, ok==true              accepted
-					--   ready==true, ok==false, "full"     rejected by policy
-					--   ready==true, ok==nil               closed
-					--   ready==false                       would block (not possible for reject_newest/drop_oldest)
 					if not r1 then
-						-- Should not happen with bounded non-blocking policies.
 						return false, 'would_block'
 					end
 					if r2 == true then return true, nil end
@@ -1024,36 +1191,28 @@ function Connection:call_op(topic, payload, opts)
 					return false, r3 or 'full'
 				end
 
-				-- Attempt a single reply receive without yielding.
-				-- Returns: have:boolean, payload:any|nil, err:any|nil
 				local function try_recv_reply()
-					-- Use raw mailbox recv_op's try_fn directly (non-yielding).
 					local rxop = rep_ep._rx:recv_op()
 					local ready, v = rxop.try_fn()
 					if not ready then
 						return false, nil, nil
 					end
 					if v == nil then
-						-- closed and drained
 						return true, nil, 'closed'
 					end
-					-- v is Message
 					return true, v.payload, nil
 				end
 
-				-- Probe step: observational only; never performs side effects.
 				local function probe_step()
 					local now = runtime.now()
 					if now >= deadline then
 						return true, function () return nil, 'timeout' end
 					end
 
-					-- If reply already buffered, ask to run immediately.
 					if phase == 'wait_reply' and reply_buffered() then
 						return false, 'run'
 					end
 
-					-- If reply endpoint is closed (and no buffered reply), this is terminal.
 					if phase == 'wait_reply' and reply_closed() and not reply_buffered() then
 						return true, function () return nil, 'closed' end
 					end
@@ -1065,12 +1224,9 @@ function Connection:call_op(topic, payload, opts)
 						return false, 'timer'
 					end
 
-					-- wait_reply
 					return false, 'any'
 				end
 
-				-- Run step: performs bounded, non-yielding progress.
-				-- Returns either (true, thunk) terminal, or (false, want) to block.
 				local function run_step()
 					local now = runtime.now()
 					if now >= deadline then
@@ -1085,9 +1241,7 @@ function Connection:call_op(topic, payload, opts)
 						local ok_pub, reason = try_publish_once()
 						if ok_pub then
 							phase = 'wait_reply'
-							-- Fall through to reply attempt in the same tick.
 						else
-							-- Retry policy matches previous implementation.
 							if reason ~= 'full' and reason ~= 'no_route' and reason ~= 'closed' then
 								return true, function () return nil, tostring(reason) end
 							end
@@ -1104,7 +1258,6 @@ function Connection:call_op(topic, payload, opts)
 						end
 					end
 
-					-- phase == 'wait_reply'
 					local have, payload_out, err = try_recv_reply()
 					if have then
 						if err ~= nil then
@@ -1113,16 +1266,13 @@ function Connection:call_op(topic, payload, opts)
 						return true, function () return payload_out, nil end
 					end
 
-					-- Not ready: wait for either reply or deadline.
 					return false, 'any'
 				end
 
-				-- Registration: arm wake-ups without exposing the scheduler.
 				---@param task Task
 				---@param waker table
 				---@param want any
 				local function register(task, waker, want)
-					-- Always arm the deadline timer (cannot cancel; benign if it fires after completion).
 					waker:at_time(deadline, task)
 
 					if want == 'run' then
@@ -1135,13 +1285,10 @@ function Connection:call_op(topic, payload, opts)
 						return { unlink = function () return false end }
 					end
 
-					-- want == 'any' (or anything else): wait for reply arrival and deadline.
-					-- Rx:on_message uses the waker; no scheduler is referenced.
 					local tok = rep_ep._rx:on_message(task, waker)
 					return tok or { unlink = function () return false end }
 				end
 
-				-- Build the op: waitable2 returns packed results; we always return a thunk.
 				return wait.waitable2(register, probe_step, run_step)
 					:wrap(function (th)
 						return th()
@@ -1159,8 +1306,6 @@ end
 -- Bus public API
 --------------------------------------------------------------------------------
 
---- connect([opts]) -> Connection
---- opts: { principal?: any }
 function Bus:connect(opts)
 	opts = opts or {}
 	if type(opts) ~= 'table' then
@@ -1176,17 +1321,20 @@ end
 
 function Bus:stats()
 	local connections, dropped = 0, 0
+	local retained_watches = 0
 	for conn in pairs(self._conns) do
 		connections = connections + 1
 		dropped = dropped + conn:dropped()
+		for _ in pairs(conn._rws or {}) do retained_watches = retained_watches + 1 end
 	end
 	return {
-		connections = connections,
-		dropped     = dropped,
-		queue_len   = self._q_length,
-		full_policy = self._full,
-		s_wild      = self._s_wild,
-		m_wild      = self._m_wild,
+		connections      = connections,
+		dropped          = dropped,
+		queue_len        = self._q_length,
+		full_policy      = self._full,
+		s_wild           = self._s_wild,
+		m_wild           = self._m_wild,
+		retained_watches = retained_watches,
 	}
 end
 
@@ -1210,26 +1358,29 @@ local function new(params)
 	local m_wild = params.m_wild or '#'
 
 	return setmetatable({
-		_q_length  = q_length,
-		_full      = full_default,
-		_s_wild    = s_wild,
-		_m_wild    = m_wild,
-		_topics    = trie.new_pubsub(s_wild, m_wild),
-		_retained  = trie.new_retained(s_wild, m_wild),
-		_conns     = setmetatable({}, { __mode = 'k' }),
-		_endpoints = {}, -- lane B store
-		_authoriser = params.authoriser,
+		_q_length          = q_length,
+		_full              = full_default,
+		_s_wild            = s_wild,
+		_m_wild            = m_wild,
+		_topics            = trie.new_pubsub(s_wild, m_wild),
+		_retained          = trie.new_retained(s_wild, m_wild),
+		_retained_watchers = trie.new_pubsub(s_wild, m_wild),
+		_conns             = setmetatable({}, { __mode = 'k' }),
+		_endpoints         = {},
+		_authoriser        = params.authoriser,
 	}, Bus)
 end
 
 return {
 	new = new,
 
-	Bus          = Bus,
-	Connection   = Connection,
-	Subscription = Subscription,
-	Endpoint     = Endpoint,
-	Message      = Message,
+	Bus           = Bus,
+	Connection    = Connection,
+	Subscription  = Subscription,
+	RetainedWatch = RetainedWatch,
+	RetainedEvent = RetainedEvent,
+	Endpoint      = Endpoint,
+	Message       = Message,
 
 	-- Re-export trie literal helper for convenience.
 	literal = trie.literal,

--- a/tests/test.lua
+++ b/tests/test.lua
@@ -30,6 +30,14 @@ local function assert_in_set(v, set, msg)
 	end
 end
 
+local function topic_str(topic)
+	local parts = {}
+	for i = 1, #(topic or {}) do
+		parts[i] = tostring(topic[i])
+	end
+	return table.concat(parts, '/')
+end
+
 -- A standard “deadline arm”: returns (nil, 'timeout').
 local function timeout_op(dt)
 	return Sleep.sleep_op(dt):wrap(function ()
@@ -341,6 +349,254 @@ local function test_retained_query_wildcards_and_unretain()
 	assert_timeout(msg, err)
 
 	print('Retained message (wildcards + unretain) test passed!')
+end
+
+--------------------------------------------------------------------------------
+-- Retained watch feed tests
+--------------------------------------------------------------------------------
+
+local function test_retained_watch_replay_and_live_changes()
+	local bus  = Bus.new({ m_wild = '#', s_wild = '+' })
+	local conn = bus:connect()
+
+	conn:retain({ 'watch', 'a' }, 'A1')
+
+	local rw = conn:watch_retained({ 'watch', '#' }, {
+		queue_len = 10,
+		full      = 'drop_oldest',
+		replay    = true,
+	})
+
+	assert_eq(conn:stats().retained_watches, 1)
+	assert_eq(bus:stats().retained_watches, 1)
+
+	do
+		local ev, err = fibers.perform(rw:recv_op())
+		assert(err == nil and ev, tostring(err))
+		assert_eq(ev.op, 'retain')
+		assert_eq(topic_str(ev.topic), 'watch/a')
+		assert_eq(ev.payload, 'A1')
+	end
+
+	conn:retain({ 'watch', 'b' }, 'B1')
+
+	do
+		local ev, err = fibers.perform(rw:recv_op())
+		assert(err == nil and ev, tostring(err))
+		assert_eq(ev.op, 'retain')
+		assert_eq(topic_str(ev.topic), 'watch/b')
+		assert_eq(ev.payload, 'B1')
+	end
+
+	conn:unretain({ 'watch', 'a' })
+
+	do
+		local ev, err = fibers.perform(rw:recv_op())
+		assert(err == nil and ev, tostring(err))
+		assert_eq(ev.op, 'unretain')
+		assert_eq(topic_str(ev.topic), 'watch/a')
+		assert(ev.payload == nil, 'expected nil payload for unretain')
+	end
+
+	-- Ordinary publish should not appear on retained watch feeds.
+	conn:publish({ 'watch', 'c' }, 'PUBONLY')
+
+	do
+		local which, ev, err = select_named({
+			ev       = rw:recv_op(),
+			deadline = timeout_op(TMO),
+		})
+		assert_eq(which, 'deadline')
+		assert_timeout(ev, err)
+	end
+
+	rw:unwatch()
+
+	assert_eq(conn:stats().retained_watches, 0)
+	assert_eq(bus:stats().retained_watches, 0)
+
+	print('Retained watch (replay + live changes) test passed!')
+end
+
+local function test_retained_watch_no_replay()
+	local bus  = Bus.new({ m_wild = '#', s_wild = '+' })
+	local conn = bus:connect()
+
+	conn:retain({ 'watch', 'nr' }, 'OLD')
+
+	local rw = conn:watch_retained({ 'watch', 'nr' }, {
+		queue_len = 4,
+		full      = 'drop_oldest',
+		replay    = false,
+	})
+
+	do
+		local which, ev, err = select_named({
+			ev       = rw:recv_op(),
+			deadline = timeout_op(TMO),
+		})
+		assert_eq(which, 'deadline')
+		assert_timeout(ev, err)
+	end
+
+	conn:retain({ 'watch', 'nr' }, 'NEW')
+
+	do
+		local ev, err = fibers.perform(rw:recv_op())
+		assert(err == nil and ev, tostring(err))
+		assert_eq(ev.op, 'retain')
+		assert_eq(topic_str(ev.topic), 'watch/nr')
+		assert_eq(ev.payload, 'NEW')
+	end
+
+	rw:unwatch()
+
+	print('Retained watch (no replay) test passed!')
+end
+
+local function test_retained_watch_wildcards_and_literals()
+	local bus  = Bus.new({ m_wild = '#', s_wild = '+' })
+	local conn = bus:connect()
+
+	conn:retain({ 'metrics', '+' }, 'PLUS')
+	conn:retain({ 'metrics', 'abc' }, 'ABC')
+	conn:retain({ 'lit', '#', 'x' }, 'HASHMID')
+
+	local rw_wild = conn:watch_retained({ 'metrics', '+' }, {
+		queue_len = 10,
+		full      = 'drop_oldest',
+		replay    = true,
+	})
+	local rw_lit_plus = conn:watch_retained({ 'metrics', Bus.literal('+') }, {
+		queue_len = 10,
+		full      = 'drop_oldest',
+		replay    = true,
+	})
+	local rw_lit_hash_mid = conn:watch_retained({ 'lit', Bus.literal('#'), 'x' }, {
+		queue_len = 10,
+		full      = 'drop_oldest',
+		replay    = true,
+	})
+
+	do
+		local got = {}
+		for _ = 1, 2 do
+			local ev, err = fibers.perform(rw_wild:recv_op())
+			assert(err == nil and ev, tostring(err))
+			assert_eq(ev.op, 'retain')
+			got[ev.payload] = true
+		end
+		assert(got.PLUS and got.ABC, 'wild retained watch should replay PLUS and ABC')
+	end
+
+	do
+		local ev, err = fibers.perform(rw_lit_plus:recv_op())
+		assert(err == nil and ev, tostring(err))
+		assert_eq(ev.op, 'retain')
+		assert_eq(ev.payload, 'PLUS')
+		assert_eq(topic_str(ev.topic), 'metrics/+')
+	end
+
+	do
+		local which, ev, err = select_named({
+			ev       = rw_lit_plus:recv_op(),
+			deadline = timeout_op(TMO),
+		})
+		assert_eq(which, 'deadline')
+		assert_timeout(ev, err)
+	end
+
+	do
+		local ev, err = fibers.perform(rw_lit_hash_mid:recv_op())
+		assert(err == nil and ev, tostring(err))
+		assert_eq(ev.op, 'retain')
+		assert_eq(ev.payload, 'HASHMID')
+		assert_eq(topic_str(ev.topic), 'lit/#/x')
+	end
+
+	rw_wild:unwatch()
+	rw_lit_plus:unwatch()
+	rw_lit_hash_mid:unwatch()
+
+	print('Retained watch (wildcards + literal wrapper) test passed!')
+end
+
+local function test_retained_watch_unwatch_and_disconnect()
+	local bus  = Bus.new({ m_wild = '#', s_wild = '+' })
+	local conn = bus:connect()
+
+	local rw = conn:watch_retained({ 'watch', 'close' }, {
+		queue_len = 4,
+		full      = 'drop_oldest',
+	})
+
+	rw:unwatch()
+
+	do
+		local which, ev, err = select_named({
+			ev       = rw:recv_op(),
+			deadline = timeout_op(LONG_TMO),
+		})
+		assert_eq(which, 'ev')
+		assert(ev == nil)
+		assert_eq(err, 'unwatched')
+	end
+
+	local rw2 = conn:watch_retained({ 'watch', 'disconnect' }, {
+		queue_len = 4,
+		full      = 'drop_oldest',
+	})
+
+	conn:disconnect()
+
+	do
+		local which, ev, err = select_named({
+			ev       = rw2:recv_op(),
+			deadline = timeout_op(LONG_TMO),
+		})
+		assert_eq(which, 'ev')
+		assert(ev == nil)
+		assert_eq(err, 'disconnected')
+	end
+
+	print('Retained watch (unwatch + disconnect) test passed!')
+end
+
+local function test_retained_watch_bounded_queue()
+	local bus  = Bus.new({ m_wild = '#', s_wild = '+', q_length = 10 })
+	local conn = bus:connect()
+
+	local rw = conn:watch_retained({ 'watch', 'bounded' }, {
+		queue_len = 1,
+		full      = 'reject_newest',
+	})
+
+	conn:retain({ 'watch', 'bounded' }, 'one')
+	conn:retain({ 'watch', 'bounded' }, 'two')
+
+	do
+		local ev, err = fibers.perform(rw:recv_op())
+		assert(err == nil and ev, tostring(err))
+		assert_eq(ev.op, 'retain')
+		assert_eq(ev.payload, 'one')
+	end
+
+	do
+		local which, ev, err = select_named({
+			ev       = rw:recv_op(),
+			deadline = timeout_op(TMO),
+		})
+		assert_eq(which, 'deadline')
+		assert_timeout(ev, err)
+	end
+
+	assert_eq(rw:dropped(), 1)
+	assert_eq(conn:dropped(), 1)
+	assert_eq(bus:stats().dropped, 1)
+
+	rw:unwatch()
+
+	print('Retained watch (bounded queue) test passed!')
 end
 
 --------------------------------------------------------------------------------
@@ -716,7 +972,7 @@ local function test_laneB_call_success()
 	local reply, err = client:call({ 'rpc', 'echo' }, 'hi', { timeout = LONG_TMO })
 	assert(err == nil, tostring(err))
 	assert_eq(reply, 'reply:hi')
-	ep:unbind()     -- closes the endpoint mailbox; recv() returns nil; fibre exits
+	ep:unbind()
 
 	print('Lane B call (success) test passed!')
 end
@@ -914,6 +1170,12 @@ local function test_authz_denies_without_admin_role()
 	assert(not ok4, 'expected call_op perform without admin role to be denied')
 	assert(tostring(err4):match('permission denied'), tostring(err4))
 
+	local ok5, err5 = pcall(function()
+		conn_viewer:watch_retained({ 'authz', 'deny', 'watch' })
+	end)
+	assert(not ok5, 'expected watch_retained without admin role to be denied')
+	assert(tostring(err5):match('permission denied'), tostring(err5))
+
 	print('Authz deny test passed!')
 end
 
@@ -958,6 +1220,16 @@ local function test_authz_admin_allows_and_records_actions()
 		assert_eq(which, 'deadline')
 		assert_timeout(msg, err)
 	end
+
+	-- watch_retained
+	local rw = conn1:watch_retained({ 'authz', 'watch' }, { replay = true })
+	conn1:retain({ 'authz', 'watch' }, 'W')
+	do
+		local ev, err = fibers.perform(rw:recv_op())
+		assert(err == nil and ev and ev.op == 'retain')
+		assert_eq(ev.payload, 'W')
+	end
+	rw:unwatch()
 
 	-- bind + publish_one
 	local ep = conn1:bind({ 'authz', 'ep' }, { queue_len = 1 })
@@ -1013,14 +1285,15 @@ local function test_authz_admin_allows_and_records_actions()
 		actions[ctx.action] = true
 	end
 
-	assert(actions.subscribe,   'expected subscribe action to be authorised')
-	assert(actions.publish,     'expected publish action to be authorised')
-	assert(actions.retain,      'expected retain action to be authorised')
-	assert(actions.unretain,    'expected unretain action to be authorised')
-	assert(actions.bind,        'expected bind action to be authorised')
-	assert(actions.publish_one, 'expected publish_one action to be authorised')
-	assert(actions.request,     'expected request action to be authorised')
-	assert(actions.call,        'expected call action to be authorised')
+	assert(actions.subscribe,      'expected subscribe action to be authorised')
+	assert(actions.publish,        'expected publish action to be authorised')
+	assert(actions.retain,         'expected retain action to be authorised')
+	assert(actions.unretain,       'expected unretain action to be authorised')
+	assert(actions.watch_retained, 'expected watch_retained action to be authorised')
+	assert(actions.bind,           'expected bind action to be authorised')
+	assert(actions.publish_one,    'expected publish_one action to be authorised')
+	assert(actions.request,        'expected request action to be authorised')
+	assert(actions.call,           'expected call action to be authorised')
 
 	print('Authz admin allow/record test passed!')
 end
@@ -1040,6 +1313,12 @@ fibers.run(function ()
 
 	test_retained_msg_basic()
 	test_retained_query_wildcards_and_unretain()
+
+	test_retained_watch_replay_and_live_changes()
+	test_retained_watch_no_replay()
+	test_retained_watch_wildcards_and_literals()
+	test_retained_watch_unwatch_and_disconnect()
+	test_retained_watch_bounded_queue()
 
 	test_q_overflow_drop_oldest_default()
 	test_q_overflow_reject_newest_override()


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] 🍕 Feature
- [x] 📝 Documentation Update
- [x] ✅ Test

## Description
Adds retained-watch support to `lua-bus`.

- introduces `conn:watch_retained(...)` / `conn:unwatch_retained(...)`
- adds `RetainedWatch` handles and retained lifecycle events for `retain` / `unretain`
- supports optional initial replay of matching retained state via `replay = true`
- updates bus stats and connection stats to include retained watches
- adds test coverage for retained-watch replay, live changes, wildcard/literal matching, closure, queue bounds, and authz
- updates the README to document the new API and semantics

## Related Issues, Tickets & Documents

## Screenshots/Recordings

## Manual test
- [x] 👍 yes

## Manual test description
Ran the bus test suite, including the new retained-watch cases, and confirmed the updated API and README match current behaviour.

## Added tests?
- [x] 👍 yes

## Added to documentation?
- [x] 📜 README.md

## [optional] Are there any post-deployment tasks we need to perform?
No.