### PR TITLE
Refactor bus API with immutable origins and retained views

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/src/fiber*
+/src/coxpcall*
+/src/trie*
+*.DS_Store

--- a/readme.md
+++ b/readme.md
@@ -2,107 +2,233 @@
 
 ## Overview
 
-The `bus` module provides an in-process messaging bus built on `fibers` and trie-based topic matching.
+The `bus` module provides a bounded, in-process messaging fabric built on `fibers` and trie-based topic matching.
 
 It is intended for cooperative, single-threaded systems running under `fibers.run(...)`, where:
 
-* delivery is **bounded** (every subscription, endpoint, and retained watch has a bounded queue, possibly zero-length), and
-* publishing and routing are **non-blocking** (slow consumers do not stall publishers).
+* delivery is **bounded**: every subscription, retained watch, and endpoint has a finite queue, which may be zero-length, and
+* routing is **non-blocking**: a slow consumer does not stall publishers or callers.
+
+The bus exposes two public planes only:
+
+* a **state/event plane** for publish/subscribe and retained state, and
+* a **command plane** for concrete point-to-point request/reply.
+
+This keeps the programming model small and explicit:
+
+* **publish** facts,
+* **retain** current truth,
+* **call** owned actions.
+
+## Internal indexes
 
 The bus uses three tries:
 
-* a **pubsub trie** for ordinary subscriptions (wildcards allowed in stored keys; queries are literal),
-* a **retained trie** for retained state (stored keys are literal; wildcards allowed in queries), and
-* a **retained-watch trie** for observing retained-state lifecycle events (wildcards allowed in stored keys; queries are literal).
+* a **pubsub trie** for ordinary subscriptions
+  wildcards are allowed in stored subscription patterns; published topics are concrete queries
 
-## Key ideas
+* a **retained trie** for retained state
+  retained topics are stored as concrete keys; subscriptions and retained watches may query with wildcards
 
-* **Bus**: the shared router, retained store, endpoint registry, and retained-watch registry.
-* **Connection**: the capability you pass to services; scope-bound by default.
-* **Subscription**: a per-subscriber mailbox for ordinary publish fanout.
-* **RetainedWatch**: a per-watcher mailbox for retained-state lifecycle events.
-* **Endpoint**: a concrete point-to-point mailbox for lane B delivery.
-* **Message**: `{ topic, payload, reply_to?, id? }` delivered to subscriptions and endpoints.
-* **RetainedEvent**: `{ op, topic, payload?, reply_to?, id? }` delivered to retained watches.
+* a **retained-watch trie** for retained lifecycle feeds
+  wildcards are allowed in stored watch patterns; retained writes/removals are concrete queries
+
+Endpoints are stored separately in a concrete-topic registry.
+
+---
+
+## Core concepts
+
+### Bus
+
+The shared router, retained store, endpoint registry, and retained-watch registry.
+
+### Connection
+
+The capability handed to services. A connection is scope-bound by default: when the current scope exits, the connection is disconnected automatically.
+
+### Subscription
+
+A bounded mailbox receiving ordinary published `Message` values.
+
+### RetainedWatch
+
+A bounded mailbox receiving retained-state lifecycle `RetainedEvent` values.
+
+### Endpoint
+
+A bounded mailbox receiving concrete point-to-point `Request` values.
+
+### Message
+
+Delivered to ordinary subscriptions:
+
+```lua
+{
+  topic   = <Topic>,
+  payload = <any>,
+  origin  = <Origin>,
+}
+```
+
+### RetainedEvent
+
+Delivered to retained watches:
+
+```lua
+{
+  op      = 'retain' | 'unretain',
+  topic   = <Topic>,
+  payload = <any|nil>,
+  origin  = <Origin>,
+}
+```
+
+### Request
+
+Delivered to bound endpoints:
+
+```lua
+{
+  topic   = <Topic>,
+  payload = <any>,
+  origin  = <Origin>,
+
+  reply = function(self, value) ... end,
+  fail  = function(self, err) ... end,
+  done  = function(self) ... end,
+}
+```
+
+A `Request` is the command-plane reply mechanism. There are no public reply topics.
+
+### Origin
+
+Immutable provenance attached by the bus:
+
+```lua
+{
+  kind       = <string>,
+  conn_id    = <string|nil>,
+  principal  = <any|nil>,
+  link_id    = <string|nil>,
+  peer_node  = <string|nil>,
+  peer_sid   = <string|nil>,
+  generation = <integer|nil>,
+  extra      = <table|nil>,
+}
+```
+
+For ordinary local traffic, only some fields are populated. Fields such as `link_id`, `peer_node`, `peer_sid`, and `generation` are intended for provenance-aware federation layers such as `fabric`.
+
+---
 
 ## Assumptions and semantics
 
-* Use only **inside fibers** (from within `fibers.run(...)`).
-* Ordinary publish fanout is **best-effort**:
+* Use from within `fibers.run(...)`.
+* Delivery is always bounded.
+* The bus never uses blocking queue policy.
+* Slow consumers lose data according to their mailbox policy; they do not stall the system.
+* Timeouts are not built into subscriptions or retained watches; compose them externally with `fibers.choice`, `fibers.named_choice`, and `fibers.sleep.sleep_op(...)`.
+* `call(...)` supports timeout/deadline directly because bounded request/reply is part of the command plane.
 
-  * the bus attempts a single non-blocking enqueue per matching subscription,
-  * if enqueue would block or is rejected by policy, the message is dropped for that subscription.
-* Retained-watch delivery is also **best-effort** and bounded:
-
-  * retained writes and retained removals are turned into retained events,
-  * the bus attempts a single non-blocking enqueue per matching retained watch,
-  * if enqueue would block or is rejected by policy, the event is dropped for that watch.
-* Timeouts are not built in; compose them externally using `fibers.named_choice` / `fibers.choice` plus `fibers.sleep.sleep_op`.
+---
 
 ## Topics, wildcards, and literals
 
-Topics are token arrays (dense tables indexed `1..n`), for example:
+A topic is a dense token array, for example:
 
 ```lua
 { 'net', 'link' }
-````
+```
 
-Wildcards are supported in subscription and retained-watch patterns:
+Tokens must be strings or numbers.
 
-* single-level wildcard token: `+` (configurable via `s_wild`)
-* multi-level wildcard token: `#` (configurable via `m_wild`)
+### Wildcards
 
-### Literal tokens (escaping wildcards)
+Subscription and retained-watch patterns may use:
 
-If you need to use the wildcard symbols as ordinary tokens, wrap them with `bus.literal(...)` (re-exported from `trie.literal`):
+* single-level wildcard: `+`
+* multi-level wildcard: `#`
+
+These tokens are configurable with `s_wild` and `m_wild`.
+
+### Literal wildcard tokens
+
+If the wildcard symbols must be treated as ordinary literal topic elements, wrap them with `bus.literal(...)`:
 
 ```lua
 local Bus = require 'bus'
 
-local topic = { 'cfg', Bus.literal('+') }  -- matches the literal "+" token
+local topic = { 'cfg', Bus.literal('+') }
 ```
 
-A literal token is treated as concrete for endpoint binding, point-to-point routing, and request/reply topics.
+A literal wildcard token is treated as concrete for:
+
+* endpoint binding,
+* point-to-point calls,
+* and ordinary literal matching.
+
+---
 
 ## Delivery, queues, and full policy
 
 Each subscription, retained watch, and endpoint mailbox has:
 
-* `queue_len` (number, **≥ 0**)
+* `queue_len` — integer, `>= 0`
 * `full` policy:
 
   * `"drop_oldest"` (default)
   * `"reject_newest"`
-  * `"block"` is rejected (the bus must remain bounded and non-blocking)
 
-`"drop_newest"` is deprecated and not supported; use `"reject_newest"`.
+`"block"` is rejected. The bus is intentionally bounded and non-blocking.
 
-### Queue length = 0
+### Queue length `0`
 
-A `queue_len` of `0` creates a rendezvous-style mailbox:
+A queue length of `0` creates rendezvous-style delivery:
 
 * delivery succeeds only if a receiver is waiting at send time,
-* otherwise delivery would block, so the bus drops (or rejects) the item.
+* otherwise the item is rejected by mailbox policy.
 
-For subscriptions and retained watches, this is useful when you only want delivery if someone is actively waiting.
+This can be useful for highly transient traffic where stale queueing is undesirable.
 
 ### Drop accounting
 
-Drops are tracked per handle and can be queried:
+Drops are tracked per handle and in aggregate:
 
-* `sub:dropped()` — drops for that subscription
-* `watch:dropped()` — drops for that retained watch
-* `ep:dropped()` — drops for that endpoint
-* `conn:dropped()` — sum of drops across owned subscriptions, retained watches, and endpoints
+* `sub:dropped()`
+* `watch:dropped()`
+* `ep:dropped()`
+* `conn:dropped()`
+* `bus:stats().dropped`
 
-The counter aggregates both:
+The count includes both:
 
 * buffered evictions under `"drop_oldest"`, and
-* rejections under `"reject_newest"`.
+* admission failures under `"reject_newest"`.
 
-## Retained state and retained watches
+---
 
-Retained messages are stored under concrete topics and replayed to future matching subscriptions.
+## State/event plane
+
+The state/event plane consists of:
+
+* `publish`
+* `retain`
+* `unretain`
+* `subscribe`
+* `watch_retained`
+
+### Ordinary publish
+
+An ordinary publish fans out to matching subscriptions only.
+
+Publishing is best-effort per subscriber:
+
+* the bus attempts one immediate enqueue into each matching subscription mailbox,
+* if that subscriber cannot accept the item, it is dropped for that subscriber.
+
+### Retained state
 
 A retained write:
 
@@ -112,8 +238,8 @@ conn:retain({ 'fw', 'version' }, '1.2.3')
 
 does two things:
 
-1. it publishes the message to ordinary subscribers, and
-2. it stores the retained value for future replay.
+1. it publishes the message to matching ordinary subscriptions, and
+2. it stores the retained value under that concrete topic.
 
 A retained removal:
 
@@ -121,108 +247,174 @@ A retained removal:
 conn:unretain({ 'fw', 'version' })
 ```
 
-removes the retained value. It does **not** publish an ordinary message.
+removes the retained value. It does not publish an ordinary message.
 
-### Watching retained-state lifecycle
+### Retained lifecycle feeds
 
-If you need to observe retained writes and removals as events, use `watch_retained(...)`.
+Retained watches receive `RetainedEvent` values when retained state is written or removed.
 
-A retained watch receives `RetainedEvent` records:
+On retain:
 
-* on retain:
+```lua
+{
+  op      = 'retain',
+  topic   = ...,
+  payload = ...,
+  origin  = ...,
+}
+```
 
-  ```lua
-  {
-    op       = 'retain',
-    topic    = ...,
-    payload  = ...,
-    reply_to = ...,
-    id       = ...,
-  }
-  ```
+On unretain:
 
-* on unretain:
-
-  ```lua
-  {
-    op    = 'unretain',
-    topic = ...,
-  }
-  ```
+```lua
+{
+  op     = 'unretain',
+  topic  = ...,
+  origin = ...,
+}
+```
 
 Retained watches are independent of ordinary subscriptions.
 
-### Replay on watch creation
+### Replay on retained watch creation
 
-`watch_retained(...)` accepts `replay = true` to emit synthetic `retain` events for the current retained items that match the pattern.
+`watch_retained(...)` accepts `replay = true`, which emits synthetic `retain` events for the current retained values matching the pattern.
 
-This is useful for consumers that need both:
+This is useful when a consumer needs:
 
 * the current retained image, and
 * subsequent retained changes.
+
+---
+
+## Command plane
+
+The command plane consists of:
+
+* `bind`
+* `call`
+
+A call targets exactly one concrete endpoint topic.
+
+Endpoint handlers do not reply by publishing to reply topics. They receive a `Request` object and complete it directly with:
+
+* `req:reply(value)`, or
+* `req:fail(err)`.
+
+This keeps request/reply separate from ordinary pub/sub.
+
+### Endpoint delivery
+
+Bound endpoints are point-to-point and admission-signalled:
+
+* if no endpoint is bound, the call fails with `no_route`
+* if the endpoint queue is full, the call fails with `full`
+* if the endpoint closes before replying, the caller sees `closed`
+* if the deadline expires first, the caller sees `timeout`
+
+Exact error values depend on the bus implementation, but these are the intended categories.
+
+---
 
 ## Installation
 
 Dependencies:
 
-* `fibers` (`fibers.op`, `fibers.performer`, `fibers.scope`, `fibers.mailbox`)
-* `trie` (pubsub + retained; supports `trie.literal`)
-* `uuid`
+* `fibers`
+* `trie` with pubsub and retained support
+* `trie.literal`
 
-Load:
+Load with:
 
 ```lua
 local Bus = require 'bus'
 ```
 
+---
+
 ## API summary
 
-### Bus
+## Bus
 
 * `Bus.new(params?) -> bus`
-* `bus:connect([opts]) -> conn`
+* `bus:connect(opts?) -> conn`
 * `bus:stats() -> table`
-* `Bus.literal(v) -> literal_token` (or `require('bus').literal(v)`)
+* `Bus.literal(v) -> literal_token`
 
-Constructor parameters:
+### Constructor parameters
 
-* `q_length?: integer`
-* `full?: "drop_oldest"|"reject_newest"`
-* `s_wild?: string|number`
-* `m_wild?: string|number`
-* `authoriser?: function|table`
+```lua
+{
+  q_length?   = integer,
+  full?       = "drop_oldest" | "reject_newest",
+  s_wild?     = string | number,
+  m_wild?     = string | number,
+  authoriser? = function | table,
+}
+```
 
-`bus:connect(opts?)` currently accepts:
+### `connect` options
 
-* `principal?: any`
+```lua
+{
+  principal?   = any,
+  origin_base? = table|nil,
+}
+```
 
-### Connection
+`origin_base` is optional per-connection origin metadata that the bus may merge into emitted origin values.
+
+---
+
+## Connection
+
+### State/event plane
 
 * `conn:publish(topic, payload[, opts]) -> true`
 * `conn:retain(topic, payload[, opts]) -> true`
-* `conn:unretain(topic) -> true`
+* `conn:unretain(topic[, opts]) -> true`
 * `conn:subscribe(topic[, opts]) -> sub`
 * `conn:unsubscribe(sub) -> true`
 * `conn:watch_retained(topic[, opts]) -> watch`
 * `conn:unwatch_retained(watch) -> true`
-* `conn:disconnect() -> true`
-* `conn:is_disconnected() -> boolean`
-* `conn:principal() -> any|nil`
-* `conn:dropped() -> number`
-* `conn:stats() -> table`
-* `conn:request_sub(topic, payload[, opts]) -> sub`
-* `conn:request_once_op(topic, payload[, opts]) -> Op`
 
-Lane B (opt-in):
+### Command plane
 
 * `conn:bind(topic[, opts]) -> endpoint`
 * `conn:unbind(endpoint) -> true`
-* `conn:publish_one_op(topic, payload[, opts]) -> Op`
-* `conn:publish_one(topic, payload[, opts]) -> boolean, reason|nil`
 * `conn:call_op(topic, payload[, opts]) -> Op`
-* `conn:call(topic, payload[, opts]) -> reply|nil, err|nil`
+* `conn:call(topic, payload[, opts]) -> value|nil, err|nil`
 
-### Subscription
+### Lifecycle and stats
+
+* `conn:disconnect() -> true`
+* `conn:is_disconnected() -> boolean`
+* `conn:principal() -> any|nil`
+* `conn:dropped() -> integer`
+* `conn:stats() -> table`
+
+### Common options
+
+For `publish`, `retain`, `unretain`, and `call`, implementations may accept:
+
+```lua
+{
+  origin? = table|nil,
+}
+```
+
+For `call`, implementations may also accept:
+
+```lua
+{
+  timeout?  = number,
+  deadline? = number,
+}
+```
+
+---
+
+## Subscription
 
 * `sub:recv_op() -> Op` yielding `(Message|nil, err|string|nil)`
 * `sub:recv() -> Message|nil, err|string|nil`
@@ -230,42 +422,60 @@ Lane B (opt-in):
 * `sub:iter() -> iterator<Message>`
 * `sub:payloads() -> iterator<any>`
 * `sub:why() -> any|nil`
-* `sub:dropped() -> number`
+* `sub:dropped() -> integer`
 * `sub:topic() -> Topic`
 * `sub:stats() -> table`
 
-### RetainedWatch
+---
+
+## RetainedWatch
 
 * `watch:recv_op() -> Op` yielding `(RetainedEvent|nil, err|string|nil)`
 * `watch:recv() -> RetainedEvent|nil, err|string|nil`
 * `watch:unwatch() -> true`
 * `watch:iter() -> iterator<RetainedEvent>`
 * `watch:why() -> any|nil`
-* `watch:dropped() -> number`
+* `watch:dropped() -> integer`
 * `watch:topic() -> Topic`
 * `watch:stats() -> table`
 
-### Endpoint (lane B)
+---
 
-* `ep:recv_op() -> Op` yielding `(Message|nil, err|string|nil)`
-* `ep:recv() -> Message|nil, err|string|nil`
-* `ep:iter() -> iterator<Message>`
-* `ep:payloads() -> iterator<any>`
+## Endpoint
+
+* `ep:recv_op() -> Op` yielding `(Request|nil, err|string|nil)`
+* `ep:recv() -> Request|nil, err|string|nil`
+* `ep:iter() -> iterator<Request>`
 * `ep:unbind() -> true`
 * `ep:why() -> any|nil`
-* `ep:dropped() -> number`
+* `ep:dropped() -> integer`
 * `ep:topic() -> Topic`
+
+---
+
+## Request
+
+* `req.topic`
+* `req.payload`
+* `req.origin`
+* `req:reply(value) -> boolean`
+* `req:fail(err) -> boolean`
+* `req:done() -> boolean`
+
+A request may be completed once only. Subsequent `reply` or `fail` attempts return false or have no effect, depending on implementation.
+
+---
 
 ## Usage
 
-### Create a bus
+## Create a bus
 
 ```lua
 local Bus = require 'bus'
 
 local bus = Bus.new{
-  q_length = 10,            -- default queue length
-  full     = 'drop_oldest', -- default full policy
+  q_length = 10,
+  full     = 'drop_oldest',
   s_wild   = '+',
   m_wild   = '#',
 }
@@ -279,9 +489,9 @@ local bus = Bus.new{
 }
 ```
 
-### Connect (scope-bound)
+## Connect
 
-`bus:connect()` is bound to the current scope: on scope exit the connection is disconnected.
+Connections are scope-bound by default:
 
 ```lua
 local conn = bus:connect()
@@ -295,83 +505,94 @@ local conn = bus:connect{
 }
 ```
 
-### Publish
+---
+
+## Publish
 
 ```lua
 conn:publish({ 'net', 'link' }, { ifname = 'eth0', up = true })
 ```
 
-Publishing never blocks. If a subscriber cannot accept immediately, that subscriber drops (or rejects) the message.
+Publishing never waits for consumers.
 
-### Retain and unretain
-
-Retained messages are stored and replayed to matching future subscriptions:
+Consume it:
 
 ```lua
-conn:retain({ 'fw', 'version' }, '1.2.3')
-```
-
-Remove retained state:
-
-```lua
-conn:unretain({ 'fw', 'version' })
-```
-
-### Subscribe
-
-Default behaviour uses the bus defaults (`q_length`, `full`):
-
-```lua
-local sub = conn:subscribe({ 'fw', '#' })
-```
-
-Override queue length and policy:
-
-```lua
-local sub = conn:subscribe({ 'net', '+' }, { queue_len = 50, full = 'reject_newest' })
-```
-
-Rendezvous subscription:
-
-```lua
-local sub = conn:subscribe({ 'events', 'transient' }, { queue_len = 0, full = 'reject_newest' })
-```
-
-### Receive (sync) and compose a timeout
-
-`recv()` blocks until a message arrives or the subscription closes:
-
-```lua
+local sub = conn:subscribe({ 'net', 'link' })
 local msg, err = sub:recv()
+
 if msg then
-  print(msg.payload)
+  print(msg.payload.ifname, msg.payload.up)
+  print(msg.origin.kind)
 else
   print('closed:', err)
 end
 ```
 
-Timeouts are composed externally:
+---
+
+## Retain and unretain
+
+```lua
+conn:retain({ 'fw', 'version' }, '1.2.3')
+conn:unretain({ 'fw', 'version' })
+```
+
+A matching future subscription receives retained replay best-effort and bounded by its mailbox.
+
+---
+
+## Subscribe
+
+```lua
+local sub = conn:subscribe({ 'fw', '#' })
+```
+
+Override queue settings:
+
+```lua
+local sub = conn:subscribe(
+  { 'net', '+' },
+  { queue_len = 50, full = 'reject_newest' }
+)
+```
+
+Rendezvous subscription:
+
+```lua
+local sub = conn:subscribe(
+  { 'events', 'transient' },
+  { queue_len = 0, full = 'reject_newest' }
+)
+```
+
+---
+
+## Compose a timeout
+
+Subscriptions and retained watches do not have built-in timeouts. Compose them externally:
 
 ```lua
 local fibers = require 'fibers'
 local sleep  = require 'fibers.sleep'
 
-local ev = fibers.named_choice{
+local which, msg, err = fibers.perform(fibers.named_choice{
   msg      = sub:recv_op(),
-  deadline = sleep.sleep_op(1.0),
-}
+  deadline = sleep.sleep_op(1.0):wrap(function ()
+    return nil, 'timeout'
+  end),
+})
 
-local which, msg, err = fibers.perform(ev)
 if which == 'msg' then
-  -- msg may be nil if the subscription closed
+  -- msg may be nil if closed
 else
-  -- deadline fired
+  -- timeout
 end
 ```
 
-### Watch retained-state changes
+---
 
-Create a retained watch:
+## Watch retained state
 
 ```lua
 local watch = conn:watch_retained({ 'config', '#' }, {
@@ -387,116 +608,82 @@ Consume retained events:
 local ev, err = watch:recv()
 if ev then
   if ev.op == 'retain' then
-    print('retained update:', ev.payload)
-  elseif ev.op == 'unretain' then
-    print('retained removal:', table.concat(ev.topic, '/'))
+    print('updated:', ev.payload)
+  else
+    print('removed:', table.concat(ev.topic, '/'))
   end
 else
   print('watch closed:', err)
 end
 ```
 
-Compose with a timeout:
+---
 
-```lua
-local fibers = require 'fibers'
-local sleep  = require 'fibers.sleep'
-
-local evsel = fibers.named_choice{
-  event    = watch:recv_op(),
-  deadline = sleep.sleep_op(1.0),
-}
-
-local which, ev, err = fibers.perform(evsel)
-if which == 'event' then
-  -- ev may be nil if the watch closed
-else
-  -- deadline fired
-end
-```
-
-### Unsubscribe, unwatch, and disconnect
-
-```lua
-sub:unsubscribe()     -- idempotent, wakes waiters
-watch:unwatch()       -- idempotent, wakes waiters
-conn:disconnect()     -- idempotent, closes all owned subs/watches/endpoints
-```
-
-## Request/reply
-
-### Multi-reply: `request_sub`
-
-Creates a fresh `reply_to` topic, subscribes to it first, then publishes the request.
-
-```lua
-local replies = conn:request_sub(
-  { 'rpc', 'get_status' },
-  { verbose = true },
-  { queue_len = 10, full = 'drop_oldest' }
-)
-
-for msg in replies:iter() do
-  print('reply:', msg.payload)
-end
-```
-
-### Single reply: `request_once_op`
-
-Returns an `Op` that yields the first reply message (or closes). It uses a temporary subscription with `queue_len = 1` and `'reject_newest'`, and always unsubscribes via `op.bracket`.
-
-```lua
-local fibers = require 'fibers'
-local sleep  = require 'fibers.sleep'
-
-local ev = fibers.named_choice{
-  reply    = conn:request_once_op({ 'rpc', 'ping' }, { answer = 42 }),
-  timeout  = sleep.sleep_op(1.0),
-}
-
-local which, msg, err = fibers.perform(ev)
-if which == 'reply' and msg then
-  print('reply:', msg.payload)
-else
-  print('no reply')
-end
-```
-
-## Lane B: concrete point-to-point delivery
-
-Lane B is opt-in and separate from ordinary pub/sub.
-
-Use it when you want:
-
-* exactly one concrete destination topic,
-* bounded admission signalling,
-* explicit request/reply style interactions.
-
-Bind a concrete endpoint:
+## Bind an endpoint and handle requests
 
 ```lua
 local ep = conn:bind({ 'rpc', 'echo' }, { queue_len = 1 })
+
+fibers.spawn(function ()
+  while true do
+    local req, err = ep:recv()
+    if not req then
+      return
+    end
+
+    req:reply('echo:' .. tostring(req.payload))
+  end
+end)
 ```
 
-Deliver to it directly:
+A request handler may instead fail explicitly:
 
 ```lua
-local ok, reason = conn:publish_one({ 'rpc', 'echo' }, 'hello')
+req:fail('not_supported')
 ```
 
-Point-to-point topics must be concrete. Wildcards are rejected, though literal wildcard tokens are allowed via `Bus.literal(...)`.
+---
+
+## Call an endpoint
+
+```lua
+local value, err = conn:call({ 'rpc', 'echo' }, 'hello', { timeout = 1.0 })
+
+if err == nil then
+  print(value)
+else
+  print('call failed:', err)
+end
+```
+
+Point-to-point topics must be concrete. Wildcards are rejected, though literal wildcard tokens wrapped with `Bus.literal(...)` are allowed.
+
+---
+
+## Unsubscribe, unwatch, unbind, disconnect
+
+```lua
+sub:unsubscribe()
+watch:unwatch()
+ep:unbind()
+conn:disconnect()
+```
+
+All are intended to be idempotent and to wake blocked receivers promptly.
+
+---
 
 ## Authorisation
 
-The bus can be constructed with an optional `authoriser`.
+The bus may be constructed with an optional authoriser.
 
-Supported forms are:
+Supported forms:
 
 * `function(ctx) -> boolean|nil, reason?`
 * table with `:allow(ctx)`
 * table with `:authorize(ctx)`
 
-The authoriser is called with a context like:
+The authoriser receives a context such as:
 
 ```lua
 {
@@ -508,7 +695,7 @@ The authoriser is called with a context like:
 }
 ```
 
-Current actions include:
+Actions in the simplified API are:
 
 * `publish`
 * `retain`
@@ -516,15 +703,15 @@ Current actions include:
 * `subscribe`
 * `watch_retained`
 * `bind`
-* `publish_one`
-* `request`
 * `call`
 
-If authorisation fails, the operation raises an error.
+If authorisation fails, the attempted operation raises an error.
+
+---
 
 ## Stats
 
-`conn:stats()` returns:
+`conn:stats()` returns a table such as:
 
 ```lua
 {
@@ -535,7 +722,7 @@ If authorisation fails, the operation raises an error.
 }
 ```
 
-`bus:stats()` returns:
+`bus:stats()` returns a table such as:
 
 ```lua
 {
@@ -546,13 +733,46 @@ If authorisation fails, the operation raises an error.
   s_wild           = ...,
   m_wild           = ...,
   retained_watches = ...,
+  endpoints        = ...,
 }
 ```
 
+---
+
 ## Notes and limitations
 
-* Delivery is best-effort; drops are expected under overload.
-* Retained replay to new subscriptions is best-effort and bounded.
-* Retained-watch replay and live retained events are also best-effort and bounded.
-* `full = "block"` is intentionally not supported by the bus.
-* Ordinary subscriptions observe published messages; retained watches observe retained-state lifecycle. They are related, but not the same mechanism.
+* Delivery is best-effort and bounded; drops under load are expected.
+* Retained replay to new subscriptions is also bounded and best-effort.
+* Retained-watch replay and live retained events are bounded and best-effort.
+* `full = "block"` is intentionally unsupported.
+* Ordinary subscriptions observe published messages.
+* Retained watches observe retained-state lifecycle.
+* Endpoints carry command requests only; they are not part of ordinary pub/sub.
+* Origin metadata is part of bus semantics, not an application payload convention.
+
+---
+
+## Design summary
+
+The bus intentionally exposes only two public interaction styles:
+
+### State/event plane
+
+* `publish`
+* `retain`
+* `unretain`
+* `subscribe`
+* `watch_retained`
+
+### Command plane
+
+* `bind`
+* `call`
+
+That gives a small, teachable model:
+
+* publish facts,
+* retain current truth,
+* call owned actions,
+
+while keeping provenance available for observability, policy, and federation layers such as `fabric`.

--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,8 @@ That gives a small, explicit programming model:
 - **retain** current truth
 - **call** owned actions
 
+The bus also attaches immutable, bus-owned provenance (`origin`) to delivered values, so higher layers such as `fabric` can reason about source and session without relying on payload conventions.
+
 ## Internal indexes
 
 The bus uses three tries:
@@ -45,6 +47,8 @@ The shared router, retained store, endpoint registry, and retained-watch registr
 
 The capability handed to services. A connection is scope-bound by default: when the current scope exits, the connection is disconnected automatically.
 
+A connection may also derive a sibling connection on the same bus with `conn:derive(opts)`.
+
 ### Subscription
 
 A bounded mailbox receiving ordinary published `Message` values.
@@ -67,7 +71,7 @@ Delivered to ordinary subscriptions:
   payload = <any>,
   origin  = <Origin>,
 }
-```
+````
 
 ### RetainedEvent
 
@@ -78,7 +82,7 @@ Delivered to retained watches:
   op      = 'retain' | 'unretain' | 'replay_done',
   topic   = <Topic|nil>,
   payload = <any|nil>,
-  origin  = <Origin>,
+  origin  = <Origin|nil>,
 }
 ```
 
@@ -94,9 +98,10 @@ Delivered to bound endpoints:
   payload = <any>,
   origin  = <Origin>,
 
-  reply = function(self, value) ... end,
-  fail  = function(self, err) ... end,
-  done  = function(self) ... end,
+  reply   = function(self, value) ... end,
+  fail    = function(self, err) ... end,
+  abandon = function(self, reason) ... end,
+  done    = function(self) ... end,
 }
 ```
 
@@ -121,14 +126,18 @@ Immutable provenance attached by the bus:
 
 For ordinary local traffic, only some fields are populated. Fields such as `link_id`, `peer_node`, `peer_sid`, and `generation` are intended for provenance-aware federation layers such as `fabric`.
 
+The bus owns trusted provenance fields. Callers may attach only `origin.extra` through publish/retain/unretain/call options.
+
 ## Assumptions and semantics
 
-- Use from within `fibers.run(...)`.
-- Delivery is always bounded.
-- The bus never uses blocking queue policy.
-- Slow consumers lose data according to their mailbox policy; they do not stall the system.
-- Timeouts are not built into subscriptions or retained watches; compose them externally with `fibers.choice`, `fibers.named_choice`, and `fibers.sleep.sleep_op(...)`.
-- `call(...)` supports timeout/deadline directly because bounded request/reply is part of the command plane.
+* Use from within `fibers.run(...)`.
+* Delivery is always bounded.
+* The bus never uses blocking queue policy.
+* Slow consumers lose data according to their mailbox policy; they do not stall the system.
+* Timeouts are not built into subscriptions or retained watches; compose them externally with `fibers.choice`, `fibers.named_choice`, and `fibers.sleep.sleep_op(...)`.
+* `call(...)` supports timeout/deadline directly because bounded request/reply is part of the command plane.
+* Origins are immutable once created.
+* `origin.extra`, if present, is immutable too.
 
 ## Topics, wildcards, and literals
 
@@ -144,8 +153,8 @@ Tokens must be strings or numbers.
 
 Subscription and retained-watch patterns may use:
 
-- single-level wildcard: `+`
-- multi-level wildcard: `#`
+* single-level wildcard: `+`
+* multi-level wildcard: `#`
 
 These tokens are configurable with `s_wild` and `m_wild`.
 
@@ -161,18 +170,20 @@ local topic = { 'cfg', Bus.literal('+') }
 
 A literal wildcard token is treated as concrete for:
 
-- endpoint binding
-- point-to-point calls
-- ordinary literal matching
+* endpoint binding
+* point-to-point calls
+* ordinary literal matching
+* retained matching
 
 ## Delivery, queues, and full policy
 
 Each subscription, retained watch, and endpoint mailbox has:
 
-- `queue_len` — integer, `>= 0`
-- `full` policy:
-  - `"drop_oldest"` (default)
-  - `"reject_newest"`
+* `queue_len` — integer, `>= 0`
+* `full` policy:
+
+  * `"drop_oldest"` (default)
+  * `"reject_newest"`
 
 `"block"` is rejected. The bus is intentionally bounded and non-blocking.
 
@@ -180,8 +191,8 @@ Each subscription, retained watch, and endpoint mailbox has:
 
 A queue length of `0` creates rendezvous-style delivery:
 
-- delivery succeeds only if a receiver is waiting at send time
-- otherwise the item is rejected by mailbox policy
+* delivery succeeds only if a receiver is waiting at send time
+* otherwise the item is rejected by mailbox policy
 
 This can be useful for highly transient traffic where stale queueing is undesirable.
 
@@ -189,26 +200,26 @@ This can be useful for highly transient traffic where stale queueing is undesira
 
 Drops are tracked per handle and in aggregate:
 
-- `sub:dropped()`
-- `watch:dropped()`
-- `ep:dropped()`
-- `conn:dropped()`
-- `bus:stats().dropped`
+* `sub:dropped()`
+* `watch:dropped()`
+* `ep:dropped()`
+* `conn:dropped()`
+* `bus:stats().dropped`
 
 The count includes both:
 
-- buffered evictions under `"drop_oldest"`, and
-- admission failures under `"reject_newest"`
+* buffered evictions under `"drop_oldest"`, and
+* admission failures under `"reject_newest"`
 
 ## State/event plane
 
 The state/event plane consists of:
 
-- `publish`
-- `retain`
-- `unretain`
-- `subscribe`
-- `watch_retained`
+* `publish`
+* `retain`
+* `unretain`
+* `subscribe`
+* `watch_retained`
 
 ### Ordinary publish
 
@@ -216,8 +227,8 @@ An ordinary publish fans out to matching subscriptions only.
 
 Publishing is best-effort per subscriber:
 
-- the bus attempts one immediate enqueue into each matching subscription mailbox
-- if that subscriber cannot accept the item, it is dropped for that subscriber
+* the bus attempts one immediate enqueue into each matching subscription mailbox
+* if that subscriber cannot accept the item, it is dropped for that subscriber
 
 ### Retained state
 
@@ -259,9 +270,10 @@ On unretain:
 
 ```lua
 {
-  op     = 'unretain',
-  topic  = ...,
-  origin = ...,
+  op      = 'unretain',
+  topic   = ...,
+  payload = nil,
+  origin  = ...,
 }
 ```
 
@@ -269,9 +281,10 @@ On replay completion:
 
 ```lua
 {
-  op     = 'replay_done',
-  topic  = nil,
-  origin = { kind = 'bus', ... },
+  op      = 'replay_done',
+  topic   = nil,
+  payload = nil,
+  origin  = { kind = 'bus', ... },
 }
 ```
 
@@ -289,15 +302,17 @@ If the bus cannot deliver `replay_done`, the watch is closed rather than silentl
 
 The command plane consists of:
 
-- `bind`
-- `call`
+* `bind`
+* `call`
 
 A call targets exactly one concrete endpoint topic.
 
 Endpoint handlers do not reply by publishing to reply topics. They receive a `Request` object and complete it directly with:
 
-- `req:reply(value)`, or
-- `req:fail(err)`
+* `req:reply(value)`, or
+* `req:fail(err)`
+
+The bus may also abandon a request internally when the caller times out or aborts. Endpoint code should therefore treat `req:reply(...) == false` or `req:fail(...) == false` as a normal outcome.
 
 This keeps request/reply separate from ordinary pub/sub.
 
@@ -305,21 +320,53 @@ This keeps request/reply separate from ordinary pub/sub.
 
 Bound endpoints are point-to-point and admission-signalled:
 
-- if no endpoint is bound, the call fails with `no_route`
-- if the endpoint queue is full, the call fails with `full`
-- if the endpoint closes before replying, the caller sees `closed`
-- if the deadline expires first, the caller sees `timeout`
+* if no endpoint is bound, the call fails with `no_route`
+* if the endpoint queue is full, the call fails with `full`
+* if the endpoint closes before replying, the caller sees `closed`
+* if the deadline expires first, the caller sees `timeout`
 
 Exact error values depend on the bus implementation, but these are the intended categories.
+
+## Derived connections
+
+A connection can derive a sibling connection on the same bus:
+
+```lua
+local child = conn:derive()
+```
+
+This is useful when one component needs more than one connection with different roles or provenance decoration, without exposing the bus object itself.
+
+By default:
+
+* the derived connection uses the same bus
+* the derived connection inherits `principal`
+* the derived connection does **not** automatically inherit provenance decoration unless you pass it explicitly
+
+Example:
+
+```lua
+local peer_conn = conn:derive{
+  origin_factory = function ()
+    return {
+      kind       = 'fabric_import',
+      link_id    = 'link-1',
+      peer_node  = 'peer-a',
+      peer_sid   = 'sid-42',
+      generation = 7,
+    }
+  end,
+}
+```
 
 ## Installation
 
 Dependencies:
 
-- `fibers`
-- `trie` with pubsub and retained support
-- `trie.literal`
-- `uuid`
+* `fibers`
+* `trie` with pubsub and retained support
+* `trie.literal`
+* `uuid`
 
 Load with:
 
@@ -331,10 +378,10 @@ local Bus = require 'bus'
 
 ### Bus
 
-- `Bus.new(params?) -> bus`
-- `bus:connect(opts?) -> conn`
-- `bus:stats() -> table`
-- `Bus.literal(v) -> literal_token`
+* `Bus.new(params?) -> bus`
+* `bus:connect(opts?) -> conn`
+* `bus:stats() -> table`
+* `Bus.literal(v) -> literal_token`
 
 Constructor parameters:
 
@@ -352,79 +399,96 @@ Constructor parameters:
 
 ```lua
 {
-  principal?   = any,
-  origin_base? = table|nil,
+  principal?      = any,
+  origin_factory? = table|function|nil,
+  origin_base?    = table|function|nil,
 }
 ```
+
+`origin_factory` and `origin_base` are aliases for the trusted provenance source used when the bus builds `origin`.
 
 ### Connection
 
 State/event plane:
 
-- `conn:publish(topic, payload[, opts]) -> true`
-- `conn:retain(topic, payload[, opts]) -> true`
-- `conn:unretain(topic[, opts]) -> true`
-- `conn:subscribe(topic[, opts]) -> sub`
-- `conn:unsubscribe(sub) -> true`
-- `conn:watch_retained(topic[, opts]) -> watch`
-- `conn:unwatch_retained(watch) -> true`
+* `conn:publish(topic, payload[, opts]) -> true`
+* `conn:retain(topic, payload[, opts]) -> true`
+* `conn:unretain(topic[, opts]) -> true`
+* `conn:subscribe(topic[, opts]) -> sub`
+* `conn:unsubscribe(sub) -> true`
+* `conn:watch_retained(topic[, opts]) -> watch`
+* `conn:unwatch_retained(watch) -> true`
 
 Command plane:
 
-- `conn:bind(topic[, opts]) -> endpoint`
-- `conn:unbind(endpoint) -> true`
-- `conn:call_op(topic, payload[, opts]) -> Op`
-- `conn:call(topic, payload[, opts]) -> value|nil, err|nil`
+* `conn:bind(topic[, opts]) -> endpoint`
+* `conn:unbind(endpoint) -> true`
+* `conn:call_op(topic, payload[, opts]) -> Op`
+* `conn:call(topic, payload[, opts]) -> value|nil, err|nil`
 
 Lifecycle and stats:
 
-- `conn:disconnect() -> true`
-- `conn:is_disconnected() -> boolean`
-- `conn:principal() -> any|nil`
-- `conn:dropped() -> integer`
-- `conn:stats() -> table`
+* `conn:derive([opts]) -> conn`
+* `conn:disconnect() -> true`
+* `conn:is_disconnected() -> boolean`
+* `conn:principal() -> any|nil`
+* `conn:dropped() -> integer`
+* `conn:stats() -> table`
+
+Per-operation options for `publish`, `retain`, `unretain`, and `call`:
+
+```lua
+{
+  extra?    = table,
+  timeout?  = number,
+  deadline? = number,
+}
+```
+
+`extra` becomes immutable `origin.extra` on delivered objects.
 
 ### Subscription
 
-- `sub:recv_op() -> Op` yielding `(Message|nil, err|string|nil)`
-- `sub:recv() -> Message|nil, err|string|nil`
-- `sub:unsubscribe() -> true`
-- `sub:iter() -> iterator<Message>`
-- `sub:payloads() -> iterator<any>`
-- `sub:why() -> any|nil`
-- `sub:dropped() -> integer`
-- `sub:topic() -> Topic`
-- `sub:stats() -> table`
+* `sub:recv_op() -> Op` yielding `(Message|nil, err|string|nil)`
+* `sub:recv() -> Message|nil, err|string|nil`
+* `sub:unsubscribe() -> true`
+* `sub:iter() -> iterator<Message>`
+* `sub:payloads() -> iterator<any>`
+* `sub:why() -> any|nil`
+* `sub:dropped() -> integer`
+* `sub:topic() -> Topic`
+* `sub:stats() -> table`
 
 ### RetainedWatch
 
-- `watch:recv_op() -> Op` yielding `(RetainedEvent|nil, err|string|nil)`
-- `watch:recv() -> RetainedEvent|nil, err|string|nil`
-- `watch:unwatch() -> true`
-- `watch:iter() -> iterator<RetainedEvent>`
-- `watch:why() -> any|nil`
-- `watch:dropped() -> integer`
-- `watch:topic() -> Topic`
-- `watch:stats() -> table`
+* `watch:recv_op() -> Op` yielding `(RetainedEvent|nil, err|string|nil)`
+* `watch:recv() -> RetainedEvent|nil, err|string|nil`
+* `watch:unwatch() -> true`
+* `watch:iter() -> iterator<RetainedEvent>`
+* `watch:why() -> any|nil`
+* `watch:dropped() -> integer`
+* `watch:topic() -> Topic`
+* `watch:stats() -> table`
 
 ### Endpoint
 
-- `ep:recv_op() -> Op` yielding `(Request|nil, err|string|nil)`
-- `ep:recv() -> Request|nil, err|string|nil`
-- `ep:iter() -> iterator<Request>`
-- `ep:unbind() -> true`
-- `ep:why() -> any|nil`
-- `ep:dropped() -> integer`
-- `ep:topic() -> Topic`
+* `ep:recv_op() -> Op` yielding `(Request|nil, err|string|nil)`
+* `ep:recv() -> Request|nil, err|string|nil`
+* `ep:iter() -> iterator<Request>`
+* `ep:unbind() -> true`
+* `ep:why() -> any|nil`
+* `ep:dropped() -> integer`
+* `ep:topic() -> Topic`
 
 ### Request
 
-- `req.topic`
-- `req.payload`
-- `req.origin`
-- `req:reply(value) -> boolean`
-- `req:fail(err) -> boolean`
-- `req:done() -> boolean`
+* `req.topic`
+* `req.payload`
+* `req.origin`
+* `req:reply(value) -> boolean`
+* `req:fail(err) -> boolean`
+* `req:abandon(reason) -> boolean`
+* `req:done() -> boolean`
 
 A request may be completed once only.
 
@@ -467,10 +531,55 @@ local conn = bus:connect{
 }
 ```
 
+With provenance decoration:
+
+```lua
+local conn = bus:connect{
+  principal = my_principal,
+  origin_factory = function ()
+    return {
+      kind       = 'fabric_import',
+      link_id    = 'link-1',
+      peer_node  = 'peer-a',
+      peer_sid   = 'sid-42',
+      generation = 7,
+    }
+  end,
+}
+```
+
+### Derive a sibling connection
+
+```lua
+local child = conn:derive()
+```
+
+Override provenance on the derived connection:
+
+```lua
+local imported = conn:derive{
+  origin_factory = {
+    kind       = 'fabric_import',
+    link_id    = 'link-1',
+    peer_node  = 'peer-a',
+    peer_sid   = 'sid-42',
+    generation = 7,
+  },
+}
+```
+
 ### Publish
 
 ```lua
 conn:publish({ 'net', 'link' }, { ifname = 'eth0', up = true })
+```
+
+With extra provenance fields:
+
+```lua
+conn:publish({ 'net', 'link' }, { ifname = 'eth0', up = true }, {
+  extra = { trace_id = 'abc123' },
+})
 ```
 
 Consume it:
@@ -596,6 +705,15 @@ else
 end
 ```
 
+With extra provenance fields:
+
+```lua
+local value, err = conn:call({ 'rpc', 'echo' }, 'hello', {
+  timeout = 1.0,
+  extra   = { trace_id = 'abc123' },
+})
+```
+
 Point-to-point topics must be concrete. Wildcards are rejected, though literal wildcard tokens wrapped with `Bus.literal(...)` are allowed.
 
 ### Unsubscribe, unwatch, unbind, disconnect
@@ -615,9 +733,9 @@ The bus may be constructed with an optional authoriser.
 
 Supported forms:
 
-- `function(ctx) -> boolean|nil, reason?`
-- table with `:allow(ctx)`
-- table with `:authorize(ctx)`
+* `function(ctx) -> boolean|nil, reason?`
+* table with `:allow(ctx)`
+* table with `:authorize(ctx)`
 
 The authoriser receives a context such as:
 
@@ -633,13 +751,13 @@ The authoriser receives a context such as:
 
 Actions in the simplified API are:
 
-- `publish`
-- `retain`
-- `unretain`
-- `subscribe`
-- `watch_retained`
-- `bind`
-- `call`
+* `publish`
+* `retain`
+* `unretain`
+* `subscribe`
+* `watch_retained`
+* `bind`
+* `call`
 
 If authorisation fails, the attempted operation raises an error.
 
@@ -673,14 +791,15 @@ If authorisation fails, the attempted operation raises an error.
 
 ## Notes and limitations
 
-- Delivery is best-effort and bounded; drops under load are expected.
-- Retained replay to new subscriptions is bounded and best-effort.
-- Retained-watch replay is bounded; if the bus cannot deliver the terminal `replay_done` marker, the watch is closed.
-- `full = "block"` is intentionally unsupported.
-- Ordinary subscriptions observe published messages.
-- Retained watches observe retained-state lifecycle.
-- Endpoints carry command requests only; they are not part of ordinary pub/sub.
-- Origin metadata is part of bus semantics, not an application payload convention.
+* Delivery is best-effort and bounded; drops under load are expected.
+* Retained replay to new subscriptions is bounded and best-effort.
+* Retained-watch replay is bounded; if the bus cannot deliver the terminal `replay_done` marker, the watch is closed.
+* `full = "block"` is intentionally unsupported.
+* Ordinary subscriptions observe published messages.
+* Retained watches observe retained-state lifecycle.
+* Endpoints carry command requests only; they are not part of ordinary pub/sub.
+* Origin metadata is part of bus semantics, not an application payload convention.
+* `derive()` creates a sibling connection without exposing the bus object.
 
 ## Design summary
 
@@ -688,21 +807,21 @@ The bus intentionally exposes only two public interaction styles.
 
 ### State/event plane
 
-- `publish`
-- `retain`
-- `unretain`
-- `subscribe`
-- `watch_retained`
+* `publish`
+* `retain`
+* `unretain`
+* `subscribe`
+* `watch_retained`
 
 ### Command plane
 
-- `bind`
-- `call`
+* `bind`
+* `call`
 
 That gives a small, teachable model:
 
-- publish facts
-- retain current truth
-- call owned actions
+* publish facts
+* retain current truth
+* call owned actions
 
 while keeping provenance available for observability, policy, and federation layers such as `fabric`.

--- a/readme.md
+++ b/readme.md
@@ -6,36 +6,34 @@ The `bus` module provides a bounded, in-process messaging fabric built on `fiber
 
 It is intended for cooperative, single-threaded systems running under `fibers.run(...)`, where:
 
-* delivery is **bounded**: every subscription, retained watch, and endpoint has a finite queue, which may be zero-length, and
-* routing is **non-blocking**: a slow consumer does not stall publishers or callers.
+- delivery is **bounded**: every subscription, retained watch, and endpoint has a finite queue, which may be zero-length
+- routing is **non-blocking**: a slow consumer does not stall publishers or callers
 
 The bus exposes two public planes only:
 
-* a **state/event plane** for publish/subscribe and retained state, and
-* a **command plane** for concrete point-to-point request/reply.
+- a **state/event plane** for publish/subscribe and retained state
+- a **command plane** for concrete point-to-point request/reply
 
-This keeps the programming model small and explicit:
+That gives a small, explicit programming model:
 
-* **publish** facts,
-* **retain** current truth,
-* **call** owned actions.
+- **publish** facts
+- **retain** current truth
+- **call** owned actions
 
 ## Internal indexes
 
 The bus uses three tries:
 
-* a **pubsub trie** for ordinary subscriptions
+- a **pubsub trie** for ordinary subscriptions
   wildcards are allowed in stored subscription patterns; published topics are concrete queries
 
-* a **retained trie** for retained state
+- a **retained trie** for retained state
   retained topics are stored as concrete keys; subscriptions and retained watches may query with wildcards
 
-* a **retained-watch trie** for retained lifecycle feeds
-  wildcards are allowed in stored watch patterns; retained writes/removals are concrete queries
+- a **retained-watch trie** for retained lifecycle feeds
+  wildcards are allowed in stored watch patterns; retained writes and removals are concrete queries
 
 Endpoints are stored separately in a concrete-topic registry.
-
----
 
 ## Core concepts
 
@@ -77,12 +75,14 @@ Delivered to retained watches:
 
 ```lua
 {
-  op      = 'retain' | 'unretain',
-  topic   = <Topic>,
+  op      = 'retain' | 'unretain' | 'replay_done',
+  topic   = <Topic|nil>,
   payload = <any|nil>,
   origin  = <Origin>,
 }
 ```
+
+`replay_done` is a synthetic control event emitted only for retained watches created with `replay = true`.
 
 ### Request
 
@@ -121,18 +121,14 @@ Immutable provenance attached by the bus:
 
 For ordinary local traffic, only some fields are populated. Fields such as `link_id`, `peer_node`, `peer_sid`, and `generation` are intended for provenance-aware federation layers such as `fabric`.
 
----
-
 ## Assumptions and semantics
 
-* Use from within `fibers.run(...)`.
-* Delivery is always bounded.
-* The bus never uses blocking queue policy.
-* Slow consumers lose data according to their mailbox policy; they do not stall the system.
-* Timeouts are not built into subscriptions or retained watches; compose them externally with `fibers.choice`, `fibers.named_choice`, and `fibers.sleep.sleep_op(...)`.
-* `call(...)` supports timeout/deadline directly because bounded request/reply is part of the command plane.
-
----
+- Use from within `fibers.run(...)`.
+- Delivery is always bounded.
+- The bus never uses blocking queue policy.
+- Slow consumers lose data according to their mailbox policy; they do not stall the system.
+- Timeouts are not built into subscriptions or retained watches; compose them externally with `fibers.choice`, `fibers.named_choice`, and `fibers.sleep.sleep_op(...)`.
+- `call(...)` supports timeout/deadline directly because bounded request/reply is part of the command plane.
 
 ## Topics, wildcards, and literals
 
@@ -148,8 +144,8 @@ Tokens must be strings or numbers.
 
 Subscription and retained-watch patterns may use:
 
-* single-level wildcard: `+`
-* multi-level wildcard: `#`
+- single-level wildcard: `+`
+- multi-level wildcard: `#`
 
 These tokens are configurable with `s_wild` and `m_wild`.
 
@@ -165,21 +161,18 @@ local topic = { 'cfg', Bus.literal('+') }
 
 A literal wildcard token is treated as concrete for:
 
-* endpoint binding,
-* point-to-point calls,
-* and ordinary literal matching.
-
----
+- endpoint binding
+- point-to-point calls
+- ordinary literal matching
 
 ## Delivery, queues, and full policy
 
 Each subscription, retained watch, and endpoint mailbox has:
 
-* `queue_len` — integer, `>= 0`
-* `full` policy:
-
-  * `"drop_oldest"` (default)
-  * `"reject_newest"`
+- `queue_len` — integer, `>= 0`
+- `full` policy:
+  - `"drop_oldest"` (default)
+  - `"reject_newest"`
 
 `"block"` is rejected. The bus is intentionally bounded and non-blocking.
 
@@ -187,8 +180,8 @@ Each subscription, retained watch, and endpoint mailbox has:
 
 A queue length of `0` creates rendezvous-style delivery:
 
-* delivery succeeds only if a receiver is waiting at send time,
-* otherwise the item is rejected by mailbox policy.
+- delivery succeeds only if a receiver is waiting at send time
+- otherwise the item is rejected by mailbox policy
 
 This can be useful for highly transient traffic where stale queueing is undesirable.
 
@@ -196,28 +189,26 @@ This can be useful for highly transient traffic where stale queueing is undesira
 
 Drops are tracked per handle and in aggregate:
 
-* `sub:dropped()`
-* `watch:dropped()`
-* `ep:dropped()`
-* `conn:dropped()`
-* `bus:stats().dropped`
+- `sub:dropped()`
+- `watch:dropped()`
+- `ep:dropped()`
+- `conn:dropped()`
+- `bus:stats().dropped`
 
 The count includes both:
 
-* buffered evictions under `"drop_oldest"`, and
-* admission failures under `"reject_newest"`.
-
----
+- buffered evictions under `"drop_oldest"`, and
+- admission failures under `"reject_newest"`
 
 ## State/event plane
 
 The state/event plane consists of:
 
-* `publish`
-* `retain`
-* `unretain`
-* `subscribe`
-* `watch_retained`
+- `publish`
+- `retain`
+- `unretain`
+- `subscribe`
+- `watch_retained`
 
 ### Ordinary publish
 
@@ -225,8 +216,8 @@ An ordinary publish fans out to matching subscriptions only.
 
 Publishing is best-effort per subscriber:
 
-* the bus attempts one immediate enqueue into each matching subscription mailbox,
-* if that subscriber cannot accept the item, it is dropped for that subscriber.
+- the bus attempts one immediate enqueue into each matching subscription mailbox
+- if that subscriber cannot accept the item, it is dropped for that subscriber
 
 ### Retained state
 
@@ -238,8 +229,8 @@ conn:retain({ 'fw', 'version' }, '1.2.3')
 
 does two things:
 
-1. it publishes the message to matching ordinary subscriptions, and
-2. it stores the retained value under that concrete topic.
+1. it publishes the message to matching ordinary subscriptions
+2. it stores the retained value under that concrete topic
 
 A retained removal:
 
@@ -274,32 +265,39 @@ On unretain:
 }
 ```
 
+On replay completion:
+
+```lua
+{
+  op     = 'replay_done',
+  topic  = nil,
+  origin = { kind = 'bus', ... },
+}
+```
+
 Retained watches are independent of ordinary subscriptions.
 
 ### Replay on retained watch creation
 
-`watch_retained(...)` accepts `replay = true`, which emits synthetic `retain` events for the current retained values matching the pattern.
+`watch_retained(...)` accepts `replay = true`, which emits synthetic `retain` events for the current retained values matching the pattern, followed by exactly one synthetic `replay_done` event.
 
-This is useful when a consumer needs:
+This marker means the initial replay scan has completed. It does **not** imply global quiescence. Live retained updates may occur while replay is in progress and may be observed before or after `replay_done`, depending on timing.
 
-* the current retained image, and
-* subsequent retained changes.
-
----
+If the bus cannot deliver `replay_done`, the watch is closed rather than silently dropping the marker.
 
 ## Command plane
 
 The command plane consists of:
 
-* `bind`
-* `call`
+- `bind`
+- `call`
 
 A call targets exactly one concrete endpoint topic.
 
 Endpoint handlers do not reply by publishing to reply topics. They receive a `Request` object and complete it directly with:
 
-* `req:reply(value)`, or
-* `req:fail(err)`.
+- `req:reply(value)`, or
+- `req:fail(err)`
 
 This keeps request/reply separate from ordinary pub/sub.
 
@@ -307,22 +305,21 @@ This keeps request/reply separate from ordinary pub/sub.
 
 Bound endpoints are point-to-point and admission-signalled:
 
-* if no endpoint is bound, the call fails with `no_route`
-* if the endpoint queue is full, the call fails with `full`
-* if the endpoint closes before replying, the caller sees `closed`
-* if the deadline expires first, the caller sees `timeout`
+- if no endpoint is bound, the call fails with `no_route`
+- if the endpoint queue is full, the call fails with `full`
+- if the endpoint closes before replying, the caller sees `closed`
+- if the deadline expires first, the caller sees `timeout`
 
 Exact error values depend on the bus implementation, but these are the intended categories.
-
----
 
 ## Installation
 
 Dependencies:
 
-* `fibers`
-* `trie` with pubsub and retained support
-* `trie.literal`
+- `fibers`
+- `trie` with pubsub and retained support
+- `trie.literal`
+- `uuid`
 
 Load with:
 
@@ -330,18 +327,16 @@ Load with:
 local Bus = require 'bus'
 ```
 
----
-
 ## API summary
 
-## Bus
+### Bus
 
-* `Bus.new(params?) -> bus`
-* `bus:connect(opts?) -> conn`
-* `bus:stats() -> table`
-* `Bus.literal(v) -> literal_token`
+- `Bus.new(params?) -> bus`
+- `bus:connect(opts?) -> conn`
+- `bus:stats() -> table`
+- `Bus.literal(v) -> literal_token`
 
-### Constructor parameters
+Constructor parameters:
 
 ```lua
 {
@@ -353,7 +348,7 @@ local Bus = require 'bus'
 }
 ```
 
-### `connect` options
+`connect` options:
 
 ```lua
 {
@@ -362,113 +357,80 @@ local Bus = require 'bus'
 }
 ```
 
-`origin_base` is optional per-connection origin metadata that the bus may merge into emitted origin values.
+### Connection
 
----
+State/event plane:
 
-## Connection
+- `conn:publish(topic, payload[, opts]) -> true`
+- `conn:retain(topic, payload[, opts]) -> true`
+- `conn:unretain(topic[, opts]) -> true`
+- `conn:subscribe(topic[, opts]) -> sub`
+- `conn:unsubscribe(sub) -> true`
+- `conn:watch_retained(topic[, opts]) -> watch`
+- `conn:unwatch_retained(watch) -> true`
 
-### State/event plane
+Command plane:
 
-* `conn:publish(topic, payload[, opts]) -> true`
-* `conn:retain(topic, payload[, opts]) -> true`
-* `conn:unretain(topic[, opts]) -> true`
-* `conn:subscribe(topic[, opts]) -> sub`
-* `conn:unsubscribe(sub) -> true`
-* `conn:watch_retained(topic[, opts]) -> watch`
-* `conn:unwatch_retained(watch) -> true`
+- `conn:bind(topic[, opts]) -> endpoint`
+- `conn:unbind(endpoint) -> true`
+- `conn:call_op(topic, payload[, opts]) -> Op`
+- `conn:call(topic, payload[, opts]) -> value|nil, err|nil`
 
-### Command plane
+Lifecycle and stats:
 
-* `conn:bind(topic[, opts]) -> endpoint`
-* `conn:unbind(endpoint) -> true`
-* `conn:call_op(topic, payload[, opts]) -> Op`
-* `conn:call(topic, payload[, opts]) -> value|nil, err|nil`
+- `conn:disconnect() -> true`
+- `conn:is_disconnected() -> boolean`
+- `conn:principal() -> any|nil`
+- `conn:dropped() -> integer`
+- `conn:stats() -> table`
 
-### Lifecycle and stats
+### Subscription
 
-* `conn:disconnect() -> true`
-* `conn:is_disconnected() -> boolean`
-* `conn:principal() -> any|nil`
-* `conn:dropped() -> integer`
-* `conn:stats() -> table`
+- `sub:recv_op() -> Op` yielding `(Message|nil, err|string|nil)`
+- `sub:recv() -> Message|nil, err|string|nil`
+- `sub:unsubscribe() -> true`
+- `sub:iter() -> iterator<Message>`
+- `sub:payloads() -> iterator<any>`
+- `sub:why() -> any|nil`
+- `sub:dropped() -> integer`
+- `sub:topic() -> Topic`
+- `sub:stats() -> table`
 
-### Common options
+### RetainedWatch
 
-For `publish`, `retain`, `unretain`, and `call`, implementations may accept:
+- `watch:recv_op() -> Op` yielding `(RetainedEvent|nil, err|string|nil)`
+- `watch:recv() -> RetainedEvent|nil, err|string|nil`
+- `watch:unwatch() -> true`
+- `watch:iter() -> iterator<RetainedEvent>`
+- `watch:why() -> any|nil`
+- `watch:dropped() -> integer`
+- `watch:topic() -> Topic`
+- `watch:stats() -> table`
 
-```lua
-{
-  origin? = table|nil,
-}
-```
+### Endpoint
 
-For `call`, implementations may also accept:
+- `ep:recv_op() -> Op` yielding `(Request|nil, err|string|nil)`
+- `ep:recv() -> Request|nil, err|string|nil`
+- `ep:iter() -> iterator<Request>`
+- `ep:unbind() -> true`
+- `ep:why() -> any|nil`
+- `ep:dropped() -> integer`
+- `ep:topic() -> Topic`
 
-```lua
-{
-  timeout?  = number,
-  deadline? = number,
-}
-```
+### Request
 
----
+- `req.topic`
+- `req.payload`
+- `req.origin`
+- `req:reply(value) -> boolean`
+- `req:fail(err) -> boolean`
+- `req:done() -> boolean`
 
-## Subscription
-
-* `sub:recv_op() -> Op` yielding `(Message|nil, err|string|nil)`
-* `sub:recv() -> Message|nil, err|string|nil`
-* `sub:unsubscribe() -> true`
-* `sub:iter() -> iterator<Message>`
-* `sub:payloads() -> iterator<any>`
-* `sub:why() -> any|nil`
-* `sub:dropped() -> integer`
-* `sub:topic() -> Topic`
-* `sub:stats() -> table`
-
----
-
-## RetainedWatch
-
-* `watch:recv_op() -> Op` yielding `(RetainedEvent|nil, err|string|nil)`
-* `watch:recv() -> RetainedEvent|nil, err|string|nil`
-* `watch:unwatch() -> true`
-* `watch:iter() -> iterator<RetainedEvent>`
-* `watch:why() -> any|nil`
-* `watch:dropped() -> integer`
-* `watch:topic() -> Topic`
-* `watch:stats() -> table`
-
----
-
-## Endpoint
-
-* `ep:recv_op() -> Op` yielding `(Request|nil, err|string|nil)`
-* `ep:recv() -> Request|nil, err|string|nil`
-* `ep:iter() -> iterator<Request>`
-* `ep:unbind() -> true`
-* `ep:why() -> any|nil`
-* `ep:dropped() -> integer`
-* `ep:topic() -> Topic`
-
----
-
-## Request
-
-* `req.topic`
-* `req.payload`
-* `req.origin`
-* `req:reply(value) -> boolean`
-* `req:fail(err) -> boolean`
-* `req:done() -> boolean`
-
-A request may be completed once only. Subsequent `reply` or `fail` attempts return false or have no effect, depending on implementation.
-
----
+A request may be completed once only.
 
 ## Usage
 
-## Create a bus
+### Create a bus
 
 ```lua
 local Bus = require 'bus'
@@ -489,7 +451,7 @@ local bus = Bus.new{
 }
 ```
 
-## Connect
+### Connect
 
 Connections are scope-bound by default:
 
@@ -505,15 +467,11 @@ local conn = bus:connect{
 }
 ```
 
----
-
-## Publish
+### Publish
 
 ```lua
 conn:publish({ 'net', 'link' }, { ifname = 'eth0', up = true })
 ```
-
-Publishing never waits for consumers.
 
 Consume it:
 
@@ -529,20 +487,14 @@ else
 end
 ```
 
----
-
-## Retain and unretain
+### Retain and unretain
 
 ```lua
 conn:retain({ 'fw', 'version' }, '1.2.3')
 conn:unretain({ 'fw', 'version' })
 ```
 
-A matching future subscription receives retained replay best-effort and bounded by its mailbox.
-
----
-
-## Subscribe
+### Subscribe
 
 ```lua
 local sub = conn:subscribe({ 'fw', '#' })
@@ -566,9 +518,7 @@ local sub = conn:subscribe(
 )
 ```
 
----
-
-## Compose a timeout
+### Compose a timeout
 
 Subscriptions and retained watches do not have built-in timeouts. Compose them externally:
 
@@ -582,17 +532,9 @@ local which, msg, err = fibers.perform(fibers.named_choice{
     return nil, 'timeout'
   end),
 })
-
-if which == 'msg' then
-  -- msg may be nil if closed
-else
-  -- timeout
-end
 ```
 
----
-
-## Watch retained state
+### Watch retained state
 
 ```lua
 local watch = conn:watch_retained({ 'config', '#' }, {
@@ -609,17 +551,17 @@ local ev, err = watch:recv()
 if ev then
   if ev.op == 'retain' then
     print('updated:', ev.payload)
-  else
+  elseif ev.op == 'unretain' then
     print('removed:', table.concat(ev.topic, '/'))
+  elseif ev.op == 'replay_done' then
+    print('initial retained replay complete')
   end
 else
   print('watch closed:', err)
 end
 ```
 
----
-
-## Bind an endpoint and handle requests
+### Bind an endpoint and handle requests
 
 ```lua
 local ep = conn:bind({ 'rpc', 'echo' }, { queue_len = 1 })
@@ -636,15 +578,13 @@ fibers.spawn(function ()
 end)
 ```
 
-A request handler may instead fail explicitly:
+Fail explicitly:
 
 ```lua
 req:fail('not_supported')
 ```
 
----
-
-## Call an endpoint
+### Call an endpoint
 
 ```lua
 local value, err = conn:call({ 'rpc', 'echo' }, 'hello', { timeout = 1.0 })
@@ -658,9 +598,7 @@ end
 
 Point-to-point topics must be concrete. Wildcards are rejected, though literal wildcard tokens wrapped with `Bus.literal(...)` are allowed.
 
----
-
-## Unsubscribe, unwatch, unbind, disconnect
+### Unsubscribe, unwatch, unbind, disconnect
 
 ```lua
 sub:unsubscribe()
@@ -671,17 +609,15 @@ conn:disconnect()
 
 All are intended to be idempotent and to wake blocked receivers promptly.
 
----
-
 ## Authorisation
 
 The bus may be constructed with an optional authoriser.
 
 Supported forms:
 
-* `function(ctx) -> boolean|nil, reason?`
-* table with `:allow(ctx)`
-* table with `:authorize(ctx)`
+- `function(ctx) -> boolean|nil, reason?`
+- table with `:allow(ctx)`
+- table with `:authorize(ctx)`
 
 The authoriser receives a context such as:
 
@@ -697,17 +633,15 @@ The authoriser receives a context such as:
 
 Actions in the simplified API are:
 
-* `publish`
-* `retain`
-* `unretain`
-* `subscribe`
-* `watch_retained`
-* `bind`
-* `call`
+- `publish`
+- `retain`
+- `unretain`
+- `subscribe`
+- `watch_retained`
+- `bind`
+- `call`
 
 If authorisation fails, the attempted operation raises an error.
-
----
 
 ## Stats
 
@@ -737,42 +671,38 @@ If authorisation fails, the attempted operation raises an error.
 }
 ```
 
----
-
 ## Notes and limitations
 
-* Delivery is best-effort and bounded; drops under load are expected.
-* Retained replay to new subscriptions is also bounded and best-effort.
-* Retained-watch replay and live retained events are bounded and best-effort.
-* `full = "block"` is intentionally unsupported.
-* Ordinary subscriptions observe published messages.
-* Retained watches observe retained-state lifecycle.
-* Endpoints carry command requests only; they are not part of ordinary pub/sub.
-* Origin metadata is part of bus semantics, not an application payload convention.
-
----
+- Delivery is best-effort and bounded; drops under load are expected.
+- Retained replay to new subscriptions is bounded and best-effort.
+- Retained-watch replay is bounded; if the bus cannot deliver the terminal `replay_done` marker, the watch is closed.
+- `full = "block"` is intentionally unsupported.
+- Ordinary subscriptions observe published messages.
+- Retained watches observe retained-state lifecycle.
+- Endpoints carry command requests only; they are not part of ordinary pub/sub.
+- Origin metadata is part of bus semantics, not an application payload convention.
 
 ## Design summary
 
-The bus intentionally exposes only two public interaction styles:
+The bus intentionally exposes only two public interaction styles.
 
 ### State/event plane
 
-* `publish`
-* `retain`
-* `unretain`
-* `subscribe`
-* `watch_retained`
+- `publish`
+- `retain`
+- `unretain`
+- `subscribe`
+- `watch_retained`
 
 ### Command plane
 
-* `bind`
-* `call`
+- `bind`
+- `call`
 
 That gives a small, teachable model:
 
-* publish facts,
-* retain current truth,
-* call owned actions,
+- publish facts
+- retain current truth
+- call owned actions
 
 while keeping provenance available for observability, policy, and federation layers such as `fabric`.

--- a/readme.md
+++ b/readme.md
@@ -8,32 +8,39 @@ It is intended for cooperative, single-threaded systems running under `fibers.ru
 
 - delivery is **bounded**: every subscription, retained watch, and endpoint has a finite queue, which may be zero-length
 - routing is **non-blocking**: a slow consumer does not stall publishers or callers
+- retained observation can be either **feed-based** or **materialised** through a versioned retained view
 
-The bus exposes two public planes only:
+The bus exposes two public planes:
 
-- a **state/event plane** for publish/subscribe and retained state
+- a **state/event plane** for publish/subscribe, retained state, retained lifecycle feeds, and retained materialised views
 - a **command plane** for concrete point-to-point request/reply
 
-That gives a small, explicit programming model:
+That gives a small programming model:
 
 - **publish** facts
 - **retain** current truth
+- **observe** retained truth
 - **call** owned actions
 
 The bus also attaches immutable, bus-owned provenance (`origin`) to delivered values, so higher layers such as `fabric` can reason about source and session without relying on payload conventions.
 
 ## Internal indexes
 
-The bus uses three tries:
+The bus uses trie-based topic indexes:
 
 - a **pubsub trie** for ordinary subscriptions
-  wildcards are allowed in stored subscription patterns; published topics are concrete queries
+  Wildcards are allowed in stored subscription patterns; published topics are concrete queries.
 
 - a **retained trie** for retained state
-  retained topics are stored as concrete keys; subscriptions and retained watches may query with wildcards
+  Retained topics are stored as concrete keys; subscriptions, retained watches, and retained views may query with wildcards.
 
 - a **retained-watch trie** for retained lifecycle feeds
-  wildcards are allowed in stored watch patterns; retained writes and removals are concrete queries
+  Wildcards are allowed in stored watch patterns; retained writes and removals are concrete queries.
+
+- a **retained-view trie** for retained materialised views
+  Wildcards are allowed in stored view patterns; retained writes and removals are concrete queries.
+
+Retained materialised views observe retained state directly and maintain a local versioned snapshot for event-driven assertions and observation.
 
 Endpoints are stored separately in a concrete-topic registry.
 
@@ -41,7 +48,7 @@ Endpoints are stored separately in a concrete-topic registry.
 
 ### Bus
 
-The shared router, retained store, endpoint registry, and retained-watch registry.
+The shared router, retained store, endpoint registry, retained-watch registry, and retained-view observer owner.
 
 ### Connection
 
@@ -57,13 +64,21 @@ A bounded mailbox receiving ordinary published `Message` values.
 
 A bounded mailbox receiving retained-state lifecycle `RetainedEvent` values.
 
+### RetainedView
+
+A versioned materialised view of retained state matching a topic pattern.
+
+Unlike `RetainedWatch`, a retained view is not a queue. It does not expose every retained lifecycle event. It maintains the latest matching retained messages and provides `changed_op(last_seen)` so callers can wait for the view version to change or for the view to close.
+
+This is useful for tests, probes, health reporting, and components that care about current retained truth rather than every lifecycle event.
+
 ### Endpoint
 
 A bounded mailbox receiving concrete point-to-point `Request` values.
 
 ### Message
 
-Delivered to ordinary subscriptions:
+Delivered to ordinary subscriptions and stored in retained views:
 
 ```lua
 {
@@ -126,7 +141,7 @@ Immutable provenance attached by the bus:
 
 For ordinary local traffic, only some fields are populated. Fields such as `link_id`, `peer_node`, `peer_sid`, and `generation` are intended for provenance-aware federation layers such as `fabric`.
 
-The bus owns trusted provenance fields. Callers may attach only `origin.extra` through publish/retain/unretain/call options.
+The bus owns trusted provenance fields. Callers may attach only `origin.extra` through publish, retain, unretain, and call options.
 
 ## Assumptions and semantics
 
@@ -134,10 +149,13 @@ The bus owns trusted provenance fields. Callers may attach only `origin.extra` t
 * Delivery is always bounded.
 * The bus never uses blocking queue policy.
 * Slow consumers lose data according to their mailbox policy; they do not stall the system.
-* Timeouts are not built into subscriptions or retained watches; compose them externally with `fibers.choice`, `fibers.named_choice`, and `fibers.sleep.sleep_op(...)`.
+* Timeouts are not built into subscriptions, retained watches, or retained views; compose them externally with `fibers.choice`, `fibers.named_choice`, and `fibers.sleep.sleep_op(...)`.
 * `call(...)` supports timeout/deadline directly because bounded request/reply is part of the command plane.
 * Origins are immutable once created.
 * `origin.extra`, if present, is immutable too.
+* Retained views are versioned snapshots, not event logs.
+* Retained views do not use a mailbox and therefore do not have queue overflow semantics.
+* A retained view’s `changed_op(last_seen)` is close-aware.
 
 ## Topics, wildcards, and literals
 
@@ -151,7 +169,7 @@ Tokens must be strings or numbers.
 
 ### Wildcards
 
-Subscription and retained-watch patterns may use:
+Subscription, retained-watch, and retained-view patterns may use:
 
 * single-level wildcard: `+`
 * multi-level wildcard: `#`
@@ -160,7 +178,7 @@ These tokens are configurable with `s_wild` and `m_wild`.
 
 ### Literal wildcard tokens
 
-If the wildcard symbols must be treated as ordinary literal topic elements, wrap them with `bus.literal(...)`:
+If the wildcard symbols must be treated as ordinary literal topic elements, wrap them with `Bus.literal(...)`:
 
 ```lua
 local Bus = require 'bus'
@@ -174,6 +192,7 @@ A literal wildcard token is treated as concrete for:
 * point-to-point calls
 * ordinary literal matching
 * retained matching
+* retained views
 
 ## Delivery, queues, and full policy
 
@@ -182,10 +201,12 @@ Each subscription, retained watch, and endpoint mailbox has:
 * `queue_len` — integer, `>= 0`
 * `full` policy:
 
-  * `"drop_oldest"` (default)
+  * `"drop_oldest"` default
   * `"reject_newest"`
 
 `"block"` is rejected. The bus is intentionally bounded and non-blocking.
+
+Retained views are not mailboxes and do not take queue policy for delivery. They hold the current matching retained state and expose changes through a version counter.
 
 ### Queue length `0`
 
@@ -198,7 +219,7 @@ This can be useful for highly transient traffic where stale queueing is undesira
 
 ### Drop accounting
 
-Drops are tracked per handle and in aggregate:
+Drops are tracked per queued handle and in aggregate:
 
 * `sub:dropped()`
 * `watch:dropped()`
@@ -208,8 +229,10 @@ Drops are tracked per handle and in aggregate:
 
 The count includes both:
 
-* buffered evictions under `"drop_oldest"`, and
+* buffered evictions under `"drop_oldest"`
 * admission failures under `"reject_newest"`
+
+Retained views do not contribute to drop counts.
 
 ## State/event plane
 
@@ -220,6 +243,7 @@ The state/event plane consists of:
 * `unretain`
 * `subscribe`
 * `watch_retained`
+* `retained_view`
 
 ### Ordinary publish
 
@@ -238,10 +262,11 @@ A retained write:
 conn:retain({ 'fw', 'version' }, '1.2.3')
 ```
 
-does two things:
+does three things:
 
-1. it publishes the message to matching ordinary subscriptions
-2. it stores the retained value under that concrete topic
+1. publishes the message to matching ordinary subscriptions
+2. stores the retained value under that concrete topic
+3. updates matching retained watches and retained views
 
 A retained removal:
 
@@ -249,7 +274,7 @@ A retained removal:
 conn:unretain({ 'fw', 'version' })
 ```
 
-removes the retained value. It does not publish an ordinary message.
+removes the retained value and updates matching retained watches and retained views. It does not publish an ordinary message.
 
 ### Retained lifecycle feeds
 
@@ -288,7 +313,7 @@ On replay completion:
 }
 ```
 
-Retained watches are independent of ordinary subscriptions.
+Retained watches are independent of ordinary subscriptions and retained views.
 
 ### Replay on retained watch creation
 
@@ -297,6 +322,62 @@ Retained watches are independent of ordinary subscriptions.
 This marker means the initial replay scan has completed. It does **not** imply global quiescence. Live retained updates may occur while replay is in progress and may be observed before or after `replay_done`, depending on timing.
 
 If the bus cannot deliver `replay_done`, the watch is closed rather than silently dropping the marker.
+
+### Retained materialised views
+
+A retained view gives a current snapshot of retained state matching a pattern:
+
+```lua
+local view = conn:retained_view({ 'config', '#' })
+```
+
+It is immediately initialised from the retained trie and then kept current by subsequent `retain` and `unretain` operations.
+
+A view has a monotonically increasing integer version:
+
+```lua
+local version = view:version()
+```
+
+Wait for it to change or close:
+
+```lua
+local new_version, err = fibers.perform(view:changed_op(version))
+
+if new_version then
+  version = new_version
+else
+  print('view closed:', err)
+end
+```
+
+The return shape is:
+
+```text
+version, nil  -- retained view changed
+nil, reason   -- retained view closed
+```
+
+Read one retained message:
+
+```lua
+local msg = view:get({ 'config', 'network' })
+if msg then
+  print(msg.payload)
+end
+```
+
+Read all retained messages currently in the view:
+
+```lua
+local snapshot = view:snapshot()
+```
+
+`snapshot()` returns an array of `Message` objects. It does not expose the bus’s internal topic-key map. The array is sorted deterministically by the internal topic key so that tests and diagnostics can compare it reliably.
+
+`items()` is an alias for `snapshot()` and also returns an array.
+
+A retained view is useful when the consumer wants current truth rather than a lifecycle event stream. Changes may be coalesced between observations; the version tells you that the view changed, not how many individual retained operations occurred.
 
 ## Command plane
 
@@ -309,7 +390,7 @@ A call targets exactly one concrete endpoint topic.
 
 Endpoint handlers do not reply by publishing to reply topics. They receive a `Request` object and complete it directly with:
 
-* `req:reply(value)`, or
+* `req:reply(value)`
 * `req:fail(err)`
 
 The bus may also abandon a request internally when the caller times out or aborts. Endpoint code should therefore treat `req:reply(...) == false` or `req:fail(...) == false` as a normal outcome.
@@ -325,7 +406,7 @@ Bound endpoints are point-to-point and admission-signalled:
 * if the endpoint closes before replying, the caller sees `closed`
 * if the deadline expires first, the caller sees `timeout`
 
-Exact error values depend on the bus implementation, but these are the intended categories.
+Exact error values depend on the close reason, but these are the intended categories.
 
 ## Derived connections
 
@@ -418,6 +499,7 @@ State/event plane:
 * `conn:unsubscribe(sub) -> true`
 * `conn:watch_retained(topic[, opts]) -> watch`
 * `conn:unwatch_retained(watch) -> true`
+* `conn:retained_view(topic[, opts]) -> view`
 
 Command plane:
 
@@ -435,11 +517,18 @@ Lifecycle and stats:
 * `conn:dropped() -> integer`
 * `conn:stats() -> table`
 
-Per-operation options for `publish`, `retain`, `unretain`, and `call`:
+Options for `publish`, `retain`, `unretain`, and `call`:
 
 ```lua
 {
-  extra?    = table,
+  extra? = table,
+}
+```
+
+Additional options for `call`:
+
+```lua
+{
   timeout?  = number,
   deadline? = number,
 }
@@ -452,10 +541,13 @@ Per-operation options for `publish`, `retain`, `unretain`, and `call`:
 * `sub:recv_op() -> Op` yielding `(Message|nil, err|string|nil)`
 * `sub:recv() -> Message|nil, err|string|nil`
 * `sub:unsubscribe() -> true`
+* `sub:close() -> true`
+* `sub:closed_op() -> Op` yielding `reason`
 * `sub:iter() -> iterator<Message>`
 * `sub:payloads() -> iterator<any>`
 * `sub:why() -> any|nil`
 * `sub:dropped() -> integer`
+* `sub:kind() -> "subscription"`
 * `sub:topic() -> Topic`
 * `sub:stats() -> table`
 
@@ -464,11 +556,43 @@ Per-operation options for `publish`, `retain`, `unretain`, and `call`:
 * `watch:recv_op() -> Op` yielding `(RetainedEvent|nil, err|string|nil)`
 * `watch:recv() -> RetainedEvent|nil, err|string|nil`
 * `watch:unwatch() -> true`
+* `watch:close() -> true`
+* `watch:closed_op() -> Op` yielding `reason`
 * `watch:iter() -> iterator<RetainedEvent>`
 * `watch:why() -> any|nil`
 * `watch:dropped() -> integer`
+* `watch:kind() -> "retained_watch"`
 * `watch:topic() -> Topic`
 * `watch:stats() -> table`
+
+### RetainedView
+
+* `view:version() -> integer`
+* `view:changed_op(last_seen) -> Op` yielding `(new_version|nil, err|string|nil)`
+* `view:get(topic) -> Message|nil`
+* `view:snapshot() -> Message[]`
+* `view:items() -> Message[]`
+* `view:close() -> true`
+* `view:closed_op() -> Op` yielding `reason`
+
+`changed_op(last_seen)` requires `last_seen` to be an integer. If the view version already differs from `last_seen`, it is ready immediately.
+
+Return shape:
+
+```text
+new_version, nil  -- changed
+nil, reason       -- closed
+```
+
+`snapshot()` and `items()` return an array, not a map. Each entry is a `Message`:
+
+```lua
+{
+  topic   = <Topic>,
+  payload = <any>,
+  origin  = <Origin>,
+}
+```
 
 ### Endpoint
 
@@ -476,9 +600,13 @@ Per-operation options for `publish`, `retain`, `unretain`, and `call`:
 * `ep:recv() -> Request|nil, err|string|nil`
 * `ep:iter() -> iterator<Request>`
 * `ep:unbind() -> true`
+* `ep:close() -> true`
+* `ep:closed_op() -> Op` yielding `reason`
 * `ep:why() -> any|nil`
 * `ep:dropped() -> integer`
+* `ep:kind() -> "endpoint"`
 * `ep:topic() -> Topic`
+* `ep:stats() -> table`
 
 ### Request
 
@@ -629,7 +757,7 @@ local sub = conn:subscribe(
 
 ### Compose a timeout
 
-Subscriptions and retained watches do not have built-in timeouts. Compose them externally:
+Subscriptions, retained watches, and retained views do not have built-in timeouts. Compose them externally:
 
 ```lua
 local fibers = require 'fibers'
@@ -641,6 +769,25 @@ local which, msg, err = fibers.perform(fibers.named_choice{
     return nil, 'timeout'
   end),
 })
+```
+
+For a retained view, the changed arm itself may also report closure:
+
+```lua
+local which, new_version, err = fibers.perform(fibers.named_choice{
+  changed  = view:changed_op(version),
+  deadline = sleep.sleep_op(1.0):wrap(function ()
+    return nil, 'timeout'
+  end),
+})
+
+if which == 'changed' and new_version then
+  version = new_version
+elseif which == 'changed' then
+  print('view closed:', err)
+else
+  print('timed out')
+end
 ```
 
 ### Watch retained state
@@ -669,6 +816,64 @@ else
   print('watch closed:', err)
 end
 ```
+
+### Use a retained view
+
+```lua
+local view = conn:retained_view({ 'config', '#' })
+
+local version = view:version()
+local snapshot = view:snapshot()
+
+local msg = view:get({ 'config', 'network' })
+if msg then
+  print('network config:', msg.payload)
+end
+
+local new_version, err = fibers.perform(view:changed_op(version))
+if new_version then
+  print('retained view changed:', new_version)
+else
+  print('retained view closed:', err)
+end
+```
+
+Iterate over a snapshot:
+
+```lua
+for _, msg in ipairs(view:snapshot()) do
+  print(table.concat(msg.topic, '/'), msg.payload)
+end
+```
+
+A typical loop:
+
+```lua
+local version = view:version()
+
+while true do
+  local which, new_version_or_status, err_or_reason = fibers.perform(fibers.named_choice{
+    changed = view:changed_op(version),
+    stop    = scope:cancel_op(),
+  })
+
+  if which == 'stop' then
+    return
+  end
+
+  if new_version_or_status == nil then
+    local close_reason = err_or_reason
+    return nil, close_reason
+  end
+
+  version = new_version_or_status
+
+  local snapshot = view:snapshot()
+  -- Recompute from current retained truth.
+end
+```
+
+Because `changed_op(...)` is close-aware, most loops do not need to race it separately against `view:closed_op()`. `closed_op()` remains useful when code only cares about closure.
 
 ### Bind an endpoint and handle requests
 
@@ -716,14 +921,17 @@ local value, err = conn:call({ 'rpc', 'echo' }, 'hello', {
 
 Point-to-point topics must be concrete. Wildcards are rejected, though literal wildcard tokens wrapped with `Bus.literal(...)` are allowed.
 
-### Unsubscribe, unwatch, unbind, disconnect
+### Unsubscribe, unwatch, close, unbind, disconnect
 
 ```lua
 sub:unsubscribe()
 watch:unwatch()
+view:close()
 ep:unbind()
 conn:disconnect()
 ```
+
+Queued feed handles also support `close()` as a generic close operation.
 
 All are intended to be idempotent and to wake blocked receivers promptly.
 
@@ -749,7 +957,7 @@ The authoriser receives a context such as:
 }
 ```
 
-Actions in the simplified API are:
+Actions are:
 
 * `publish`
 * `retain`
@@ -758,6 +966,8 @@ Actions in the simplified API are:
 * `watch_retained`
 * `bind`
 * `call`
+
+In the current implementation, `retained_view(...)` is authorised using the same `watch_retained` action as retained lifecycle watches, because both are retained-state observation capabilities.
 
 If authorisation fails, the attempted operation raises an error.
 
@@ -771,6 +981,7 @@ If authorisation fails, the attempted operation raises an error.
   subscriptions    = ...,
   endpoints        = ...,
   retained_watches = ...,
+  retained_views   = ...,
 }
 ```
 
@@ -785,25 +996,33 @@ If authorisation fails, the attempted operation raises an error.
   s_wild           = ...,
   m_wild           = ...,
   retained_watches = ...,
+  retained_views   = ...,
   endpoints        = ...,
 }
 ```
+
+Retained views are observational objects and do not contribute to queue drop counts.
 
 ## Notes and limitations
 
 * Delivery is best-effort and bounded; drops under load are expected.
 * Retained replay to new subscriptions is bounded and best-effort.
 * Retained-watch replay is bounded; if the bus cannot deliver the terminal `replay_done` marker, the watch is closed.
+* Retained views represent current retained truth, not every lifecycle event.
+* Retained views coalesce changes by design; use retained watches when every retain/unretain event matters.
+* Retained view snapshots are arrays of `Message` objects, not maps keyed by internal topic strings.
+* `changed_op(last_seen)` is close-aware and returns either a new version or a close reason.
 * `full = "block"` is intentionally unsupported.
 * Ordinary subscriptions observe published messages.
 * Retained watches observe retained-state lifecycle.
+* Retained views observe retained-state truth.
 * Endpoints carry command requests only; they are not part of ordinary pub/sub.
 * Origin metadata is part of bus semantics, not an application payload convention.
 * `derive()` creates a sibling connection without exposing the bus object.
 
 ## Design summary
 
-The bus intentionally exposes only two public interaction styles.
+The bus intentionally exposes a small set of interaction styles.
 
 ### State/event plane
 
@@ -812,6 +1031,7 @@ The bus intentionally exposes only two public interaction styles.
 * `unretain`
 * `subscribe`
 * `watch_retained`
+* `retained_view`
 
 ### Command plane
 
@@ -822,6 +1042,7 @@ That gives a small, teachable model:
 
 * publish facts
 * retain current truth
+* observe current truth or retained lifecycle
 * call owned actions
 
 while keeping provenance available for observability, policy, and federation layers such as `fabric`.

--- a/src/bus.lua
+++ b/src/bus.lua
@@ -838,6 +838,20 @@ function Connection:principal()
 	return self._principal
 end
 
+---@param opts? { principal?: any, origin_factory?: table|fun():table, origin_base?: table|fun():table }
+---@return Connection
+function Connection:derive(opts)
+	assert_connected(self, 1)
+	opts = require_opts_table('derive', opts, 2)
+
+	local bus = assert(self._bus)
+	if opts.principal == nil then
+		opts.principal = self._principal
+	end
+
+	return bus:connect(opts)
+end
+
 function Connection:dropped()
 	local n = 0
 	for _, set in ipairs({ self._subs, self._eps, self._rws }) do

--- a/src/bus.lua
+++ b/src/bus.lua
@@ -1,6 +1,6 @@
 -- bus.lua
 --
--- Simplified in-process bus built on fibers + trie.
+-- Simple in-process bus built on fibers + trie.
 --
 -- Public planes:
 --   * state/event plane : publish, retain, unretain, subscribe, watch_retained

--- a/src/bus.lua
+++ b/src/bus.lua
@@ -12,14 +12,16 @@
 --   * retained watch feeds (wildcard watch patterns over retain/unretain lifecycle)
 --   * bounded endpoint calls with native request/reply (no public reply topics)
 --   * immutable origin metadata attached to delivered bus objects
+--   * trusted provenance is bus-owned; callers may attach only origin.extra
 --   * principal-aware authorisation hooks on connection actions
 ---@module 'bus'
 
 local mailbox   = require 'fibers.mailbox'
+local cond      = require 'fibers.cond'
 local op        = require 'fibers.op'
 local performer = require 'fibers.performer'
-local scope_mod = require 'fibers.scope'
 local runtime   = require 'fibers.runtime'
+local scope_mod = require 'fibers.scope'
 local sleep     = require 'fibers.sleep'
 
 local trie = require 'trie'
@@ -56,7 +58,7 @@ local function unwrap_token(tok)
 end
 
 --------------------------------------------------------------------------------
--- Validation / helpers
+-- Validation / small helpers
 --------------------------------------------------------------------------------
 
 ---@param p any
@@ -110,7 +112,7 @@ local function assert_topic(topic, what, level)
 	local n = array_len(topic, level)
 
 	for i = 1, n do
-		local v = topic[i]
+		local v  = topic[i]
 		local uv = unwrap_token(v)
 		local tv = type(uv)
 		if tv ~= 'string' and tv ~= 'number' then
@@ -173,32 +175,124 @@ local function copy_table(t)
 	return out
 end
 
-local function freeze_origin(origin)
-	local data = origin
+local function freeze_shallow(t, err)
+	local data = t or {}
 	return setmetatable({}, {
-		__index = data,
-		__newindex = function () error('origin is immutable', 2) end,
-		__pairs = function () return next, data, nil end,
+		__index     = data,
+		__newindex  = function () error(err or 'table is immutable', 2) end,
+		__pairs     = function () return next, data, nil end,
 		__metatable = false,
 	})
+end
+
+---@param tx MailboxTx
+---@param value any
+---@return boolean|nil ok
+---@return string|nil reason
+local function mailbox_try_send(tx, value)
+	local send_op = tx:send_op(value)
+	local ready, ok, reason = send_op.try_fn()
+	assert(ready, 'bus mailbox unexpectedly blocked')
+	if ok == true then return true, nil end
+	if ok == nil then return nil, reason or 'closed' end
+	return false, reason or 'full'
+end
+
+---@param tx MailboxTx
+---@param value any
+local function deliver_best_effort(tx, value)
+	mailbox_try_send(tx, value)
+end
+
+local function deliver_required_or_close(tx, value, close_reason)
+	local ok, reason = mailbox_try_send(tx, value)
+	if ok == true then
+		return true
+	end
+	tx:close(close_reason or reason or 'closed')
+	return false
+end
+
+local function require_opts_table(name, opts, level)
+	if opts ~= nil and type(opts) ~= 'table' then
+		error(name .. ': opts must be a table (or nil)', (level or 1) + 1)
+	end
+	return opts or {}
+end
+
+local function resolve_queue_len(opts, default_len, name, level)
+	local qlen = opts.queue_len
+	if qlen == nil then qlen = default_len end
+	if type(qlen) ~= 'number' or qlen < 0 then
+		error(name .. ': queue_len must be >= 0', (level or 1) + 1)
+	end
+	return qlen
+end
+
+local function resolve_feed_opts(opts, default_len, default_full, name, level)
+	opts = require_opts_table(name, opts, (level or 1) + 1)
+	local qlen = resolve_queue_len(opts, default_len, name, (level or 1) + 1)
+	local full = assert_full_policy(opts.full or default_full, (level or 1) + 1) or DEFAULT_POLICY
+	return opts, qlen, full
+end
+
+local function count_keys(t)
+	local n = 0
+	for _ in pairs(t) do n = n + 1 end
+	return n
+end
+
+local function snapshot_keys(set)
+	local out = {}
+	for item in pairs(set) do
+		out[#out + 1] = item
+	end
+	return out
+end
+
+local function clear_finaliser(obj)
+	if obj._detach_finaliser then
+		obj._detach_finaliser()
+		obj._detach_finaliser = nil
+	end
+end
+
+local function own_in_scope(set, obj, detach_fn)
+	set[obj] = true
+	obj._detach_finaliser = scope_mod.current():finally(detach_fn)
+	return obj
+end
+
+local function disconnect_all(set, f)
+	for _, item in ipairs(snapshot_keys(set)) do
+		f(item)
+	end
+end
+
+--------------------------------------------------------------------------------
+-- Origin
+--------------------------------------------------------------------------------
+
+local function trusted_origin_base(conn)
+	local src = conn._origin_factory
+	if type(src) == 'function' then
+		src = src() or {}
+	end
+	return copy_table(src)
 end
 
 ---@param conn Connection
 ---@param extra? table
 ---@return Origin
 local function build_origin(conn, extra)
-	local base = conn._origin_base or {}
-	local out  = {}
-
-	for k, v in pairs(base) do out[k] = v end
-	if extra then
-		for k, v in pairs(extra) do out[k] = v end
-	end
-
+	local out = trusted_origin_base(conn)
 	if out.kind == nil then out.kind = 'local' end
 	out.conn_id   = conn._conn_id
 	out.principal = conn._principal
-	return freeze_origin(out)
+	if type(extra) == 'table' and next(extra) ~= nil then
+		out.extra = freeze_shallow(copy_table(extra), 'origin.extra is immutable')
+	end
+	return freeze_shallow(out, 'origin is immutable')
 end
 
 --------------------------------------------------------------------------------
@@ -240,14 +334,9 @@ end
 local function authorize_action(bus, principal, action, topic, extra, level)
 	level = (level or 1) + 1
 
-	local auth = bus and bus._authoriser or nil
-	if auth == nil then
+	local fn = bus and bus._authoriser or nil
+	if fn == nil then
 		return true, nil
-	end
-
-	local fn = authoriser_callable(auth)
-	if not fn then
-		error('bus authoriser must be a function or table with :allow(ctx) / :authorize(ctx)', level)
 	end
 
 	local ok, reason = fn({
@@ -297,7 +386,6 @@ end
 ---@field peer_sid string|nil
 ---@field generation integer|nil
 ---@field extra table|nil
-
 local Origin = {}
 
 ---@class Message
@@ -341,63 +429,75 @@ local function new_retained_event(op_name, topic, payload, origin)
 	}, RetainedEvent)
 end
 
-local BUS_ORIGIN = freeze_origin({ kind = 'bus' })
+local BUS_ORIGIN = freeze_shallow({ kind = 'bus' }, 'origin is immutable')
 
----@return RetainedEvent
 local function new_replay_done_event()
-	return setmetatable({
-		op      = 'replay_done',
-		topic   = nil,
-		payload = nil,
-		origin  = BUS_ORIGIN,
-	}, RetainedEvent)
+	return new_retained_event('replay_done', nil, nil, BUS_ORIGIN)
 end
 
 ---@class Request
 ---@field topic Topic
 ---@field payload any
 ---@field origin Origin
----@field _reply_tx MailboxTx
+---@field _cond Cond
 ---@field _done boolean
+---@field _ok boolean|nil
+---@field _value any
+---@field _err any
 local Request = {}
 Request.__index = Request
-
-local function request_deliver(self, record)
-	if self._done then return false end
-	self._done = true
-
-	local send_op = self._reply_tx:send_op(record)
-	local ready, ok, reason = send_op.try_fn()
-	assert(ready, 'request reply mailbox unexpectedly blocked')
-	self._reply_tx:close('done')
-	return ok == true and reason == nil
-end
 
 ---@param topic Topic
 ---@param payload any
 ---@param origin Origin
----@param reply_tx MailboxTx
 ---@return Request
-local function new_request(topic, payload, origin, reply_tx)
+local function new_request(topic, payload, origin)
 	return setmetatable({
-		topic     = topic,
-		payload   = payload,
-		origin    = origin,
-		_reply_tx = reply_tx,
-		_done     = false,
+		topic   = topic,
+		payload = payload,
+		origin  = origin,
+		_cond   = cond.new(),
+		_done   = false,
+		_ok     = nil,
+		_value  = nil,
+		_err    = nil,
 	}, Request)
 end
 
 ---@param value any
 ---@return boolean ok
 function Request:reply(value)
-	return request_deliver(self, { ok = true, value = value })
+	if self._done then return false end
+	self._done  = true
+	self._ok    = true
+	self._value = value
+	self._err   = nil
+	self._cond:signal()
+	return true
 end
 
 ---@param err any
 ---@return boolean ok
 function Request:fail(err)
-	return request_deliver(self, { ok = false, err = err })
+	if self._done then return false end
+	self._done  = true
+	self._ok    = false
+	self._value = nil
+	self._err   = err
+	self._cond:signal()
+	return true
+end
+
+---@param reason? any
+---@return boolean ok
+function Request:abandon(reason)
+	if self._done then return false end
+	self._done  = true
+	self._ok    = false
+	self._value = nil
+	self._err   = reason or 'abandoned'
+	self._cond:signal()
+	return true
 end
 
 ---@return boolean
@@ -405,40 +505,91 @@ function Request:done()
 	return self._done
 end
 
---------------------------------------------------------------------------------
--- Subscription (state/event plane)
---------------------------------------------------------------------------------
+---@return Op
+function Request:wait_reply_op()
+	if self._done then
+		if self._ok then
+			return op.always(self._value, nil)
+		end
+		return op.always(nil, self._err)
+	end
 
----@class Subscription
----@field _conn Connection|nil
----@field _topic Topic
----@field _tx MailboxTx
----@field _rx MailboxRx
----@field _detach_finaliser (fun())|nil
-local Subscription = {}
-Subscription.__index = Subscription
-
-local function new_subscription(conn, topic, tx, rx)
-	return setmetatable({
-		_conn             = conn,
-		_topic            = topic,
-		_tx               = tx,
-		_rx               = rx,
-		_detach_finaliser = nil,
-	}, Subscription)
+	return self._cond:wait_op():wrap(function ()
+		if self._ok then
+			return self._value, nil
+		end
+		return nil, self._err
+	end)
 end
 
-function Subscription:topic() return self._topic end
-function Subscription:why() return self._rx:why() end
+--------------------------------------------------------------------------------
+-- Common feed-handle behaviour
+--------------------------------------------------------------------------------
 
-function Subscription:dropped()
+local Feed = {}
+Feed.__index = Feed
+
+function Feed:topic()
+	return self._topic
+end
+
+function Feed:why()
+	return self._rx:why()
+end
+
+function Feed:dropped()
 	local tx = self._tx
 	return (tx and tx.dropped and tx:dropped()) or 0
 end
 
 ---@param reason any
-function Subscription:_close(reason)
+function Feed:_close(reason)
 	if self._tx then self._tx:close(reason) end
+end
+
+---@return Op
+function Feed:recv_op()
+	return self._rx:recv_op():wrap(function (item)
+		if item == nil then
+			return nil, tostring(self._rx:why() or 'closed')
+		end
+		return item, nil
+	end)
+end
+
+function Feed:recv()
+	return perform(self:recv_op())
+end
+
+function Feed:iter()
+	return self._rx:iter()
+end
+
+local function new_feed(mt, conn, topic, tx, rx, extra)
+	local obj = {
+		_conn             = conn,
+		_topic            = topic,
+		_tx               = tx,
+		_rx               = rx,
+		_detach_finaliser = nil,
+	}
+	if extra then
+		for k, v in pairs(extra) do obj[k] = v end
+	end
+	return setmetatable(obj, mt)
+end
+
+--------------------------------------------------------------------------------
+-- Subscription (state/event plane)
+--------------------------------------------------------------------------------
+
+---@class Subscription : Feed
+local Subscription = {}
+Subscription.__index = Subscription
+setmetatable(Subscription, { __index = Feed })
+
+local function new_subscription(conn, topic, tx, rx)
+	return new_feed(Subscription, conn, topic, tx, rx)
 end
 
 function Subscription:unsubscribe()
@@ -450,24 +601,6 @@ function Subscription:unsubscribe()
 	return conn:unsubscribe(self)
 end
 
----@return Op
-function Subscription:recv_op()
-	return self._rx:recv_op():wrap(function (msg)
-		if msg == nil then
-			return nil, tostring(self._rx:why() or 'closed')
-		end
-		return msg, nil
-	end)
-end
-
-function Subscription:recv()
-	return perform(self:recv_op())
-end
-
-function Subscription:iter()
-	return self._rx:iter()
-end
-
 function Subscription:payloads()
 	local it = self._rx:iter()
 	return function ()
@@ -477,43 +610,23 @@ function Subscription:payloads()
 end
 
 function Subscription:stats()
-	return { dropped = self:dropped(), topic = self._topic }
+	return {
+		dropped = self:dropped(),
+		topic   = self._topic,
+	}
 end
 
 --------------------------------------------------------------------------------
 -- Retained watch feed
 --------------------------------------------------------------------------------
 
----@class RetainedWatch
----@field _conn Connection|nil
----@field _topic Topic
----@field _tx MailboxTx
----@field _rx MailboxRx
----@field _detach_finaliser (fun())|nil
+---@class RetainedWatch : Feed
 local RetainedWatch = {}
 RetainedWatch.__index = RetainedWatch
+setmetatable(RetainedWatch, { __index = Feed })
 
 local function new_retained_watch(conn, topic, tx, rx)
-	return setmetatable({
-		_conn             = conn,
-		_topic            = topic,
-		_tx               = tx,
-		_rx               = rx,
-		_detach_finaliser = nil,
-	}, RetainedWatch)
-end
-
-function RetainedWatch:topic() return self._topic end
-function RetainedWatch:why() return self._rx:why() end
-
-function RetainedWatch:dropped()
-	local tx = self._tx
-	return (tx and tx.dropped and tx:dropped()) or 0
-end
-
----@param reason any
-function RetainedWatch:_close(reason)
-	if self._tx then self._tx:close(reason) end
+	return new_feed(RetainedWatch, conn, topic, tx, rx)
 end
 
 function RetainedWatch:unwatch()
@@ -525,59 +638,24 @@ function RetainedWatch:unwatch()
 	return conn:unwatch_retained(self)
 end
 
----@return Op
-function RetainedWatch:recv_op()
-	return self._rx:recv_op():wrap(function (ev)
-		if ev == nil then
-			return nil, tostring(self._rx:why() or 'closed')
-		end
-		return ev, nil
-	end)
-end
-
-function RetainedWatch:recv()
-	return perform(self:recv_op())
-end
-
-function RetainedWatch:iter()
-	return self._rx:iter()
-end
-
 function RetainedWatch:stats()
-	return { dropped = self:dropped(), topic = self._topic }
+	return {
+		dropped = self:dropped(),
+		topic   = self._topic,
+	}
 end
 
 --------------------------------------------------------------------------------
 -- Endpoint (command plane)
 --------------------------------------------------------------------------------
 
----@class Endpoint
----@field _conn Connection|nil
----@field _topic Topic
----@field _key string
----@field _tx MailboxTx
----@field _rx MailboxRx
----@field _detach_finaliser (fun())|nil
+---@class Endpoint : Feed
 local Endpoint = {}
 Endpoint.__index = Endpoint
+setmetatable(Endpoint, { __index = Feed })
 
 local function new_endpoint(conn, topic, key, tx, rx)
-	return setmetatable({
-		_conn             = conn,
-		_topic            = topic,
-		_key              = key,
-		_tx               = tx,
-		_rx               = rx,
-		_detach_finaliser = nil,
-	}, Endpoint)
-end
-
-function Endpoint:topic() return self._topic end
-function Endpoint:why() return self._rx:why() end
-
-function Endpoint:dropped()
-	local tx = self._tx
-	return (tx and tx.dropped and tx:dropped()) or 0
+	return new_feed(Endpoint, conn, topic, tx, rx, { _key = key })
 end
 
 function Endpoint:unbind()
@@ -587,24 +665,6 @@ function Endpoint:unbind()
 		return true
 	end
 	return conn:unbind(self)
-end
-
----@return Op
-function Endpoint:recv_op()
-	return self._rx:recv_op():wrap(function (req)
-		if req == nil then
-			return nil, tostring(self._rx:why() or 'closed')
-		end
-		return req, nil
-	end)
-end
-
-function Endpoint:recv()
-	return perform(self:recv_op())
-end
-
-function Endpoint:iter()
-	return self._rx:iter()
 end
 
 --------------------------------------------------------------------------------
@@ -621,34 +681,9 @@ end
 ---@field _s_wild string|number
 ---@field _m_wild string|number
 ---@field _endpoints table<string, Endpoint>
----@field _authoriser any|nil
+---@field _authoriser function|nil
 local Bus = {}
 Bus.__index = Bus
-
----@param tx MailboxTx
----@param value any
-local function deliver_best_effort(tx, value)
-	local s = scope_mod.current()
-	if s and s.try and s.status then
-		local st = select(1, s:status())
-		if st == 'running' then
-			s:try(tx:send_op(value))
-			return
-		end
-	end
-	op.perform_raw(tx:send_op(value))
-end
-
-local function deliver_required_or_close(tx, value, close_reason)
-	local send_op = tx:send_op(value)
-	local ready, ok, reason = send_op.try_fn()
-	assert(ready, 'required delivery unexpectedly blocked')
-	if ok == true then
-		return true
-	end
-	tx:close(close_reason or reason or 'closed')
-	return false
-end
 
 ---@param conn Connection
 ---@param topic Topic
@@ -770,7 +805,7 @@ end
 ---@field _rws table<RetainedWatch, boolean>
 ---@field _disconnected boolean
 ---@field _conn_id string
----@field _origin_base table
+---@field _origin_factory table|fun():table
 local Connection = {}
 Connection.__index = Connection
 
@@ -780,18 +815,18 @@ local function assert_connected(self, level)
 	end
 end
 
-local function new_connection(bus, principal, q_length, full, origin_base)
+local function new_connection(bus, principal, q_length, full, origin_factory)
 	return setmetatable({
-		_bus          = bus,
-		_principal    = principal,
-		_q_length     = q_length,
-		_full         = full,
-		_subs         = {},
-		_eps          = {},
-		_rws          = {},
-		_disconnected = false,
-		_conn_id      = tostring(uuid.new()),
-		_origin_base  = copy_table(origin_base),
+		_bus            = bus,
+		_principal      = principal,
+		_q_length       = q_length,
+		_full           = full,
+		_subs           = {},
+		_eps            = {},
+		_rws            = {},
+		_disconnected   = false,
+		_conn_id        = tostring(uuid.new()),
+		_origin_factory = origin_factory or {},
 	}, Connection)
 end
 
@@ -805,14 +840,10 @@ end
 
 function Connection:dropped()
 	local n = 0
-	for sub in pairs(self._subs) do
-		n = n + (sub:dropped() or 0)
-	end
-	for ep in pairs(self._eps) do
-		n = n + (ep:dropped() or 0)
-	end
-	for rw in pairs(self._rws) do
-		n = n + (rw:dropped() or 0)
+	for _, set in ipairs({ self._subs, self._eps, self._rws }) do
+		for item in pairs(set) do
+			n = n + (item:dropped() or 0)
+		end
 	end
 	return n
 end
@@ -827,7 +858,7 @@ function Connection:publish(topic, payload, opts)
 		opts    = opts,
 	}, 1)
 
-	self._bus:_publish(new_msg(topic, payload, build_origin(self, opts.origin)))
+	self._bus:_publish(new_msg(topic, payload, build_origin(self, opts.extra)))
 	return true
 end
 
@@ -841,7 +872,7 @@ function Connection:retain(topic, payload, opts)
 		opts    = opts,
 	}, 1)
 
-	self._bus:_retain(new_msg(topic, payload, build_origin(self, opts.origin)))
+	self._bus:_retain(new_msg(topic, payload, build_origin(self, opts.extra)))
 	return true
 end
 
@@ -854,7 +885,7 @@ function Connection:unretain(topic, opts)
 		opts = opts,
 	}, 1)
 
-	self._bus:_unretain(topic, build_origin(self, opts.origin))
+	self._bus:_unretain(topic, build_origin(self, opts.extra))
 	return true
 end
 
@@ -864,26 +895,12 @@ end
 function Connection:_subscribe_internal(topic, opts)
 	assert_connected(self, 1)
 
-	opts = opts or {}
-	if type(opts) ~= 'table' then
-		error('_subscribe_internal: opts must be a table (or nil)', 2)
-	end
+	local _, qlen, full = resolve_feed_opts(opts, self._q_length, self._full, '_subscribe_internal', 2)
+	local sub = self._bus:_subscribe(self, topic, qlen, full)
 
-	local qlen = opts.queue_len
-	if qlen == nil then qlen = self._q_length end
-	if type(qlen) ~= 'number' or qlen < 0 then
-		error('_subscribe_internal: queue_len must be >= 0', 2)
-	end
-
-	local fullp = assert_full_policy(opts.full or self._full, 2) or DEFAULT_POLICY
-
-	local sub = self._bus:_subscribe(self, topic, qlen, fullp)
-	self._subs[sub] = true
-
-	local s = scope_mod.current()
-	sub._detach_finaliser = s:finally(function () sub:unsubscribe() end)
-
-	return sub
+	return own_in_scope(self._subs, sub, function ()
+		sub:unsubscribe()
+	end)
 end
 
 function Connection:subscribe(topic, opts)
@@ -905,11 +922,7 @@ function Connection:unsubscribe(sub)
 	local owned = not not self._subs[sub]
 
 	sub:_close('unsubscribed')
-
-	if sub._detach_finaliser then
-		sub._detach_finaliser()
-		sub._detach_finaliser = nil
-	end
+	clear_finaliser(sub)
 
 	if owned then
 		self._subs[sub] = nil
@@ -925,27 +938,14 @@ end
 function Connection:_watch_retained_internal(topic, opts)
 	assert_connected(self, 1)
 
-	opts = opts or {}
-	if type(opts) ~= 'table' then
-		error('_watch_retained_internal: opts must be a table (or nil)', 2)
-	end
-
-	local qlen = opts.queue_len
-	if qlen == nil then qlen = self._q_length end
-	if type(qlen) ~= 'number' or qlen < 0 then
-		error('_watch_retained_internal: queue_len must be >= 0', 2)
-	end
-
-	local fullp = assert_full_policy(opts.full or self._full, 2) or DEFAULT_POLICY
+	opts = require_opts_table('_watch_retained_internal', opts, 2)
+	local _, qlen, full = resolve_feed_opts(opts, self._q_length, self._full, '_watch_retained_internal', 2)
 	local replay = not not opts.replay
+	local rw = self._bus:_watch_retained(self, topic, qlen, full, replay)
 
-	local rw = self._bus:_watch_retained(self, topic, qlen, fullp, replay)
-	self._rws[rw] = true
-
-	local s = scope_mod.current()
-	rw._detach_finaliser = s:finally(function () rw:unwatch() end)
-
-	return rw
+	return own_in_scope(self._rws, rw, function ()
+		rw:unwatch()
+	end)
 end
 
 function Connection:watch_retained(topic, opts)
@@ -967,11 +967,7 @@ function Connection:unwatch_retained(rw)
 	local owned = not not self._rws[rw]
 
 	rw:_close('unwatched')
-
-	if rw._detach_finaliser then
-		rw._detach_finaliser()
-		rw._detach_finaliser = nil
-	end
+	clear_finaliser(rw)
 
 	if owned then
 		self._rws[rw] = nil
@@ -987,19 +983,12 @@ end
 function Connection:_bind_internal(topic, opts)
 	assert_connected(self, 1)
 
-	opts = opts or {}
-	if type(opts) ~= 'table' then
-		error('_bind_internal: opts must be a table (or nil)', 2)
-	end
+	opts = require_opts_table('_bind_internal', opts, 2)
 
 	local bus = assert(self._bus)
 	assert_concrete_topic(bus._s_wild, bus._m_wild, topic, 'bind topic', 2)
 
-	local qlen = opts.queue_len
-	if qlen == nil then qlen = 1 end
-	if type(qlen) ~= 'number' or qlen < 0 then
-		error('_bind_internal: queue_len must be >= 0', 2)
-	end
+	local qlen = resolve_queue_len(opts, 1, '_bind_internal', 2)
 
 	local key = topic_key(topic)
 	if bus._endpoints[key] ~= nil then
@@ -1010,12 +999,9 @@ function Connection:_bind_internal(topic, opts)
 	local ep     = new_endpoint(self, topic, key, tx, rx)
 
 	bus._endpoints[key] = ep
-	self._eps[ep] = true
-
-	local s = scope_mod.current()
-	ep._detach_finaliser = s:finally(function () ep:unbind() end)
-
-	return ep
+	return own_in_scope(self._eps, ep, function ()
+		ep:unbind()
+	end)
 end
 
 function Connection:bind(topic, opts)
@@ -1033,14 +1019,11 @@ function Connection:unbind(ep)
 	if not ep or getmetatable(ep) ~= Endpoint then
 		error('unbind expects an Endpoint', 2)
 	end
+
 	local bus = self._bus
 
 	if ep._tx then ep._tx:close('unbound') end
-
-	if ep._detach_finaliser then
-		ep._detach_finaliser()
-		ep._detach_finaliser = nil
-	end
+	clear_finaliser(ep)
 
 	if self._eps[ep] then
 		self._eps[ep] = nil
@@ -1053,36 +1036,27 @@ function Connection:unbind(ep)
 	return true
 end
 
-local function call_result_op(reply_rx, reply_tx, deadline)
+local function call_result_op(req, deadline)
+	if req:done() then
+		return req:wait_reply_op()
+	end
+
 	local now = runtime.now()
 	if deadline <= now then
-		reply_tx:close('timeout')
+		req:abandon('timeout')
 		return op.always(nil, 'timeout')
 	end
 
 	local timeout_ev = sleep.sleep_op(deadline - now):wrap(function ()
-		reply_tx:close('timeout')
+		req:abandon('timeout')
 		return nil, 'timeout'
 	end)
 
-	local reply_ev = reply_rx:recv_op():wrap(function (reply)
-		if reply == nil then
-			return nil, tostring(reply_rx:why() or 'closed')
-		end
-		if reply.ok then
-			return reply.value, nil
-		end
-		return nil, reply.err
-	end)
-
-	return op.choice(reply_ev, timeout_ev)
+	return op.choice(req:wait_reply_op(), timeout_ev)
 end
 
 function Connection:call_op(topic, payload, opts)
-	opts = opts or {}
-	if type(opts) ~= 'table' then
-		error('call_op: opts must be a table (or nil)', 2)
-	end
+	opts = require_opts_table('call_op', opts, 2)
 
 	return op.guard(function ()
 		assert_connected(self, 1)
@@ -1104,45 +1078,18 @@ function Connection:call_op(topic, payload, opts)
 
 		local timeout  = (type(opts.timeout) == 'number') and opts.timeout or 1.0
 		local deadline = (type(opts.deadline) == 'number') and opts.deadline or (runtime.now() + timeout)
-		local origin   = build_origin(self, opts.origin)
+		local req      = new_request(topic, payload, build_origin(self, opts.extra))
 
-		return op.bracket(
-			function ()
-				local reply_tx, reply_rx = mailbox.new(1, { full = 'reject_newest' })
-				local req = new_request(topic, payload, origin, reply_tx)
+		local ok, reason = mailbox_try_send(ep._tx, req)
+		if ok ~= true then
+			local err = (ok == nil) and 'closed' or (reason or 'full')
+			req:abandon(err)
+			return op.always(nil, err)
+		end
 
-				local send_op = ep._tx:send_op(req)
-				local ready, ok, reason = send_op.try_fn()
-				assert(ready, 'endpoint admission unexpectedly blocked')
-
-				if ok ~= true then
-					reply_tx:close(reason or 'closed')
-					return {
-						accepted = false,
-						err      = (ok == nil) and 'closed' or (reason or 'full'),
-						reply_tx = reply_tx,
-						reply_rx = reply_rx,
-					}
-				end
-
-				return {
-					accepted = true,
-					reply_tx = reply_tx,
-					reply_rx = reply_rx,
-				}
-			end,
-			function (res)
-				if res and res.reply_tx then
-					res.reply_tx:close('done')
-				end
-			end,
-			function (res)
-				if not res.accepted then
-					return op.always(nil, res.err)
-				end
-				return call_result_op(res.reply_rx, res.reply_tx, deadline)
-			end
-		)
+		return call_result_op(req, deadline):on_abort(function ()
+			req:abandon('aborted')
+		end)
 	end)
 end
 
@@ -1157,70 +1104,44 @@ function Connection:disconnect()
 	local bus = self._bus
 	self._bus = nil
 
-	local subs = {}
-	for sub in pairs(self._subs) do subs[#subs + 1] = sub end
-	for i = 1, #subs do
-		local sub = subs[i]
-		if sub then
-			sub:_close('disconnected')
-			if sub._detach_finaliser then
-				sub._detach_finaliser()
-				sub._detach_finaliser = nil
-			end
-			if bus then bus:_unsubscribe(sub) end
-			self._subs[sub] = nil
-			if sub._conn == self then sub._conn = nil end
-		end
-	end
+	disconnect_all(self._subs, function (sub)
+		sub:_close('disconnected')
+		clear_finaliser(sub)
+		if bus then bus:_unsubscribe(sub) end
+		self._subs[sub] = nil
+		if sub._conn == self then sub._conn = nil end
+	end)
 
-	local rws = {}
-	for rw in pairs(self._rws) do rws[#rws + 1] = rw end
-	for i = 1, #rws do
-		local rw = rws[i]
-		if rw then
-			rw:_close('disconnected')
-			if rw._detach_finaliser then
-				rw._detach_finaliser()
-				rw._detach_finaliser = nil
-			end
-			if bus then bus:_unwatch_retained(rw) end
-			self._rws[rw] = nil
-			if rw._conn == self then rw._conn = nil end
-		end
-	end
+	disconnect_all(self._rws, function (rw)
+		rw:_close('disconnected')
+		clear_finaliser(rw)
+		if bus then bus:_unwatch_retained(rw) end
+		self._rws[rw] = nil
+		if rw._conn == self then rw._conn = nil end
+	end)
 
-	local eps = {}
-	for ep in pairs(self._eps) do eps[#eps + 1] = ep end
-	for i = 1, #eps do
-		local ep = eps[i]
-		if ep then
-			if ep._tx then ep._tx:close('disconnected') end
-			if bus and bus._endpoints and bus._endpoints[ep._key] == ep then
-				bus._endpoints[ep._key] = nil
-			end
-			if ep._detach_finaliser then
-				ep._detach_finaliser()
-				ep._detach_finaliser = nil
-			end
-			self._eps[ep] = nil
-			if ep._conn == self then ep._conn = nil end
+	disconnect_all(self._eps, function (ep)
+		if ep._tx then ep._tx:close('disconnected') end
+		if bus and bus._endpoints and bus._endpoints[ep._key] == ep then
+			bus._endpoints[ep._key] = nil
 		end
-	end
+		clear_finaliser(ep)
+		self._eps[ep] = nil
+		if ep._conn == self then ep._conn = nil end
+	end)
 
-	if bus and bus._conns then bus._conns[self] = nil end
+	if bus and bus._conns then
+		bus._conns[self] = nil
+	end
 	return true
 end
 
 function Connection:stats()
-	local nsubs, neps, nrws = 0, 0, 0
-	for _ in pairs(self._subs) do nsubs = nsubs + 1 end
-	for _ in pairs(self._eps) do neps = neps + 1 end
-	for _ in pairs(self._rws) do nrws = nrws + 1 end
 	return {
 		dropped          = self:dropped(),
-		subscriptions    = nsubs,
-		endpoints        = neps,
-		retained_watches = nrws,
+		subscriptions    = count_keys(self._subs),
+		endpoints        = count_keys(self._eps),
+		retained_watches = count_keys(self._rws),
 	}
 end
 
@@ -1229,27 +1150,33 @@ end
 --------------------------------------------------------------------------------
 
 function Bus:connect(opts)
-	opts = opts or {}
-	if type(opts) ~= 'table' then
-		error('connect: opts must be a table (or nil)', 2)
-	end
+	opts = require_opts_table('connect', opts, 2)
 
 	local s = scope_mod.current()
-	local conn = new_connection(self, opts.principal, self._q_length, self._full, opts.origin_base)
+	local origin_factory = opts.origin_factory or opts.origin_base
+	local conn = new_connection(self, opts.principal, self._q_length, self._full, origin_factory)
+
 	self._conns[conn] = true
-	s:finally(function () conn:disconnect() end)
+	s:finally(function ()
+		conn:disconnect()
+	end)
+
 	return conn
 end
 
 function Bus:stats()
-	local connections, dropped, endpoints = 0, 0, 0
+	local connections      = 0
+	local dropped          = 0
+	local endpoints        = 0
 	local retained_watches = 0
+
 	for conn in pairs(self._conns) do
-		connections = connections + 1
-		dropped = dropped + conn:dropped()
-		for _ in pairs(conn._rws or {}) do retained_watches = retained_watches + 1 end
-		for _ in pairs(conn._eps or {}) do endpoints = endpoints + 1 end
+		connections      = connections + 1
+		dropped          = dropped + conn:dropped()
+		endpoints        = endpoints + count_keys(conn._eps or {})
+		retained_watches = retained_watches + count_keys(conn._rws or {})
 	end
+
 	return {
 		connections      = connections,
 		dropped          = dropped,
@@ -1278,8 +1205,13 @@ local function new(params)
 	end
 
 	local full_default = assert_full_policy(params.full, 2) or DEFAULT_POLICY
-	local s_wild = params.s_wild or '+'
-	local m_wild = params.m_wild or '#'
+	local s_wild       = params.s_wild or '+'
+	local m_wild       = params.m_wild or '#'
+
+	local authoriser = authoriser_callable(params.authoriser)
+	if params.authoriser ~= nil and not authoriser then
+		error('bus authoriser must be a function or table with :allow(ctx) / :authorize(ctx)', 2)
+	end
 
 	return setmetatable({
 		_q_length          = q_length,
@@ -1291,7 +1223,7 @@ local function new(params)
 		_retained_watchers = trie.new_pubsub(s_wild, m_wild),
 		_conns             = setmetatable({}, { __mode = 'k' }),
 		_endpoints         = {},
-		_authoriser        = params.authoriser,
+		_authoriser        = authoriser,
 	}, Bus)
 end
 

--- a/src/bus.lua
+++ b/src/bus.lua
@@ -1,6 +1,6 @@
 -- bus.lua
 --
--- In-process bus built on fibers + trie.
+-- Simplified in-process bus built on fibers + trie.
 --
 -- Public planes:
 --   * state/event plane : publish, retain, unretain, subscribe, watch_retained
@@ -298,6 +298,8 @@ end
 ---@field generation integer|nil
 ---@field extra table|nil
 
+local Origin = {}
+
 ---@class Message
 ---@field topic Topic
 ---@field payload any
@@ -318,15 +320,15 @@ local function new_msg(topic, payload, origin)
 end
 
 ---@class RetainedEvent
----@field op '"retain"'|'"unretain"'
----@field topic Topic
+---@field op '"retain"'|'"unretain"'|'"replay_done"'
+---@field topic Topic|nil
 ---@field payload any|nil
 ---@field origin Origin|nil
 local RetainedEvent = {}
 RetainedEvent.__index = RetainedEvent
 
----@param op_name '"retain"'|'"unretain"'
----@param topic Topic
+---@param op_name '"retain"'|'"unretain"'|'"replay_done"'
+---@param topic Topic|nil
 ---@param payload? any
 ---@param origin? Origin
 ---@return RetainedEvent
@@ -336,6 +338,18 @@ local function new_retained_event(op_name, topic, payload, origin)
 		topic   = topic,
 		payload = payload,
 		origin  = origin,
+	}, RetainedEvent)
+end
+
+local BUS_ORIGIN = freeze_origin({ kind = 'bus' })
+
+---@return RetainedEvent
+local function new_replay_done_event()
+	return setmetatable({
+		op      = 'replay_done',
+		topic   = nil,
+		payload = nil,
+		origin  = BUS_ORIGIN,
 	}, RetainedEvent)
 end
 
@@ -625,6 +639,17 @@ local function deliver_best_effort(tx, value)
 	op.perform_raw(tx:send_op(value))
 end
 
+local function deliver_required_or_close(tx, value, close_reason)
+	local send_op = tx:send_op(value)
+	local ready, ok, reason = send_op.try_fn()
+	assert(ready, 'required delivery unexpectedly blocked')
+	if ok == true then
+		return true
+	end
+	tx:close(close_reason or reason or 'closed')
+	return false
+end
+
 ---@param conn Connection
 ---@param topic Topic
 ---@param qlen integer
@@ -710,6 +735,13 @@ function Bus:_watch_retained(conn, topic, qlen, full, replay)
 			deliver_best_effort(tx,
 				new_retained_event('retain', retained_msg.topic, retained_msg.payload, retained_msg.origin))
 		end)
+
+		if not deliver_required_or_close(tx, new_replay_done_event(), 'replay_overflow') then
+			watchers[rw] = nil
+			if next(watchers) == nil then
+				self._retained_watchers:delete(topic)
+			end
+		end
 	end
 
 	return rw
@@ -1274,6 +1306,7 @@ return {
 	Endpoint      = Endpoint,
 	Message       = Message,
 	Request       = Request,
+	Origin        = Origin,
 
 	-- Re-export trie literal helper for convenience.
 	literal = trie.literal,

--- a/src/bus.lua
+++ b/src/bus.lua
@@ -1,14 +1,18 @@
 -- bus.lua
 --
--- In-process pub/sub bus built on fibers + trie.
---  - wildcard subscriptions (pubsub trie: wildcards allowed in stored keys; literal queries)
---  - retained messages (retained trie: literal stored keys; wildcards allowed in queries)
---  - retained watch feeds (wildcard watch patterns over retain/unretain lifecycle)
---  - request/response helpers (reply_to topic)
+-- In-process bus built on fibers + trie.
 --
--- Optional extensions:
---  - lane B: bind/publish_one/call_op for admission-signalled point-to-point delivery
---  - authz : principal-aware authorisation hooks on connection actions
+-- Public planes:
+--   * state/event plane : publish, retain, unretain, subscribe, watch_retained
+--   * command plane     : bind, call
+--
+-- Key properties:
+--   * wildcard subscriptions (pubsub trie: wildcards allowed in stored keys; literal queries)
+--   * retained messages (retained trie: literal stored keys; wildcards allowed in queries)
+--   * retained watch feeds (wildcard watch patterns over retain/unretain lifecycle)
+--   * bounded endpoint calls with native request/reply (no public reply topics)
+--   * immutable origin metadata attached to delivered bus objects
+--   * principal-aware authorisation hooks on connection actions
 ---@module 'bus'
 
 local mailbox   = require 'fibers.mailbox'
@@ -16,7 +20,7 @@ local op        = require 'fibers.op'
 local performer = require 'fibers.performer'
 local scope_mod = require 'fibers.scope'
 local runtime   = require 'fibers.runtime'
-local wait      = require 'fibers.wait'
+local sleep     = require 'fibers.sleep'
 
 local trie = require 'trie'
 local uuid = require 'uuid'
@@ -162,6 +166,41 @@ local function topic_debug(topic)
 	return table.concat(parts, '/')
 end
 
+local function copy_table(t)
+	local out = {}
+	if not t then return out end
+	for k, v in pairs(t) do out[k] = v end
+	return out
+end
+
+local function freeze_origin(origin)
+	local data = origin
+	return setmetatable({}, {
+		__index = data,
+		__newindex = function () error('origin is immutable', 2) end,
+		__pairs = function () return next, data, nil end,
+		__metatable = false,
+	})
+end
+
+---@param conn Connection
+---@param extra? table
+---@return Origin
+local function build_origin(conn, extra)
+	local base = conn._origin_base or {}
+	local out  = {}
+
+	for k, v in pairs(base) do out[k] = v end
+	if extra then
+		for k, v in pairs(extra) do out[k] = v end
+	end
+
+	if out.kind == nil then out.kind = 'local' end
+	out.conn_id   = conn._conn_id
+	out.principal = conn._principal
+	return freeze_origin(out)
+end
+
 --------------------------------------------------------------------------------
 -- Authorisation
 --------------------------------------------------------------------------------
@@ -246,28 +285,35 @@ local function assert_authorized(self, action, topic, extra, level)
 end
 
 --------------------------------------------------------------------------------
--- Message / retained events
+-- Delivered objects
 --------------------------------------------------------------------------------
+
+---@class Origin
+---@field kind string
+---@field conn_id string|nil
+---@field principal any|nil
+---@field link_id string|nil
+---@field peer_node string|nil
+---@field peer_sid string|nil
+---@field generation integer|nil
+---@field extra table|nil
 
 ---@class Message
 ---@field topic Topic
 ---@field payload any
----@field reply_to Topic|nil
----@field id any|nil
+---@field origin Origin
 local Message = {}
 Message.__index = Message
 
 ---@param topic Topic
 ---@param payload any
----@param reply_to? Topic
----@param id? any
+---@param origin Origin
 ---@return Message
-local function new_msg(topic, payload, reply_to, id)
+local function new_msg(topic, payload, origin)
 	return setmetatable({
-		topic    = topic,
-		payload  = payload,
-		reply_to = reply_to,
-		id       = id,
+		topic   = topic,
+		payload = payload,
+		origin  = origin,
 	}, Message)
 end
 
@@ -275,29 +321,78 @@ end
 ---@field op '"retain"'|'"unretain"'
 ---@field topic Topic
 ---@field payload any|nil
----@field reply_to Topic|nil
----@field id any|nil
+---@field origin Origin|nil
 local RetainedEvent = {}
 RetainedEvent.__index = RetainedEvent
 
 ---@param op_name '"retain"'|'"unretain"'
 ---@param topic Topic
 ---@param payload? any
----@param reply_to? Topic
----@param id? any
+---@param origin? Origin
 ---@return RetainedEvent
-local function new_retained_event(op_name, topic, payload, reply_to, id)
+local function new_retained_event(op_name, topic, payload, origin)
 	return setmetatable({
-		op       = op_name,
-		topic    = topic,
-		payload  = payload,
-		reply_to = reply_to,
-		id       = id,
+		op      = op_name,
+		topic   = topic,
+		payload = payload,
+		origin  = origin,
 	}, RetainedEvent)
 end
 
+---@class Request
+---@field topic Topic
+---@field payload any
+---@field origin Origin
+---@field _reply_tx MailboxTx
+---@field _done boolean
+local Request = {}
+Request.__index = Request
+
+local function request_deliver(self, record)
+	if self._done then return false end
+	self._done = true
+
+	local send_op = self._reply_tx:send_op(record)
+	local ready, ok, reason = send_op.try_fn()
+	assert(ready, 'request reply mailbox unexpectedly blocked')
+	self._reply_tx:close('done')
+	return ok == true and reason == nil
+end
+
+---@param topic Topic
+---@param payload any
+---@param origin Origin
+---@param reply_tx MailboxTx
+---@return Request
+local function new_request(topic, payload, origin, reply_tx)
+	return setmetatable({
+		topic     = topic,
+		payload   = payload,
+		origin    = origin,
+		_reply_tx = reply_tx,
+		_done     = false,
+	}, Request)
+end
+
+---@param value any
+---@return boolean ok
+function Request:reply(value)
+	return request_deliver(self, { ok = true, value = value })
+end
+
+---@param err any
+---@return boolean ok
+function Request:fail(err)
+	return request_deliver(self, { ok = false, err = err })
+end
+
+---@return boolean
+function Request:done()
+	return self._done
+end
+
 --------------------------------------------------------------------------------
--- Subscription (lane A)
+-- Subscription (state/event plane)
 --------------------------------------------------------------------------------
 
 ---@class Subscription
@@ -439,7 +534,7 @@ function RetainedWatch:stats()
 end
 
 --------------------------------------------------------------------------------
--- Endpoint (lane B)
+-- Endpoint (command plane)
 --------------------------------------------------------------------------------
 
 ---@class Endpoint
@@ -482,11 +577,11 @@ end
 
 ---@return Op
 function Endpoint:recv_op()
-	return self._rx:recv_op():wrap(function (msg)
-		if msg == nil then
+	return self._rx:recv_op():wrap(function (req)
+		if req == nil then
 			return nil, tostring(self._rx:why() or 'closed')
 		end
-		return msg, nil
+		return req, nil
 	end)
 end
 
@@ -496,14 +591,6 @@ end
 
 function Endpoint:iter()
 	return self._rx:iter()
-end
-
-function Endpoint:payloads()
-	local it = self._rx:iter()
-	return function ()
-		local msg = it()
-		return msg and msg.payload or nil
-	end
 end
 
 --------------------------------------------------------------------------------
@@ -593,12 +680,12 @@ end
 function Bus:_retain(msg)
 	self:_publish(msg)
 	self._retained:insert(msg.topic, msg)
-	self:_notify_retained(new_retained_event('retain', msg.topic, msg.payload, msg.reply_to, msg.id))
+	self:_notify_retained(new_retained_event('retain', msg.topic, msg.payload, msg.origin))
 end
 
-function Bus:_unretain(topic)
+function Bus:_unretain(topic, origin)
 	self._retained:delete(topic)
-	self:_notify_retained(new_retained_event('unretain', topic))
+	self:_notify_retained(new_retained_event('unretain', topic, nil, origin))
 end
 
 ---@param conn Connection
@@ -621,7 +708,7 @@ function Bus:_watch_retained(conn, topic, qlen, full, replay)
 	if replay then
 		self._retained:each(topic, function (_k, retained_msg)
 			deliver_best_effort(tx,
-				new_retained_event('retain', retained_msg.topic, retained_msg.payload, retained_msg.reply_to, retained_msg.id))
+				new_retained_event('retain', retained_msg.topic, retained_msg.payload, retained_msg.origin))
 		end)
 	end
 
@@ -650,6 +737,8 @@ end
 ---@field _eps table<Endpoint, boolean>
 ---@field _rws table<RetainedWatch, boolean>
 ---@field _disconnected boolean
+---@field _conn_id string
+---@field _origin_base table
 local Connection = {}
 Connection.__index = Connection
 
@@ -659,7 +748,7 @@ local function assert_connected(self, level)
 	end
 end
 
-local function new_connection(bus, principal, q_length, full)
+local function new_connection(bus, principal, q_length, full, origin_base)
 	return setmetatable({
 		_bus          = bus,
 		_principal    = principal,
@@ -669,6 +758,8 @@ local function new_connection(bus, principal, q_length, full)
 		_eps          = {},
 		_rws          = {},
 		_disconnected = false,
+		_conn_id      = tostring(uuid.new()),
+		_origin_base  = copy_table(origin_base),
 	}, Connection)
 end
 
@@ -699,18 +790,12 @@ function Connection:publish(topic, payload, opts)
 	assert_topic(topic, 'topic', 1)
 
 	opts = opts or {}
-	local reply_to = opts.reply_to
-	if reply_to ~= nil then
-		assert_topic(reply_to, 'reply_to', 2)
-	end
-
 	assert_authorized(self, 'publish', topic, {
-		payload  = payload,
-		reply_to = reply_to,
-		id       = opts.id,
+		payload = payload,
+		opts    = opts,
 	}, 1)
 
-	self._bus:_publish(new_msg(topic, payload, reply_to, opts.id))
+	self._bus:_publish(new_msg(topic, payload, build_origin(self, opts.origin)))
 	return true
 end
 
@@ -719,28 +804,25 @@ function Connection:retain(topic, payload, opts)
 	assert_topic(topic, 'topic', 1)
 
 	opts = opts or {}
-	local reply_to = opts.reply_to
-	if reply_to ~= nil then
-		assert_topic(reply_to, 'reply_to', 2)
-	end
-
 	assert_authorized(self, 'retain', topic, {
-		payload  = payload,
-		reply_to = reply_to,
-		id       = opts.id,
+		payload = payload,
+		opts    = opts,
 	}, 1)
 
-	self._bus:_retain(new_msg(topic, payload, reply_to, opts.id))
+	self._bus:_retain(new_msg(topic, payload, build_origin(self, opts.origin)))
 	return true
 end
 
-function Connection:unretain(topic)
+function Connection:unretain(topic, opts)
 	assert_connected(self, 1)
 	assert_topic(topic, 'topic', 1)
 
-	assert_authorized(self, 'unretain', topic, nil, 1)
+	opts = opts or {}
+	assert_authorized(self, 'unretain', topic, {
+		opts = opts,
+	}, 1)
 
-	self._bus:_unretain(topic)
+	self._bus:_unretain(topic, build_origin(self, opts.origin))
 	return true
 end
 
@@ -867,141 +949,6 @@ function Connection:unwatch_retained(rw)
 	return true
 end
 
-function Connection:disconnect()
-	if self._disconnected then return true end
-	self._disconnected = true
-
-	local bus = self._bus
-	self._bus = nil
-
-	local subs = {}
-	for sub in pairs(self._subs) do subs[#subs + 1] = sub end
-	for i = 1, #subs do
-		local sub = subs[i]
-		if sub then
-			sub:_close('disconnected')
-			if sub._detach_finaliser then
-				sub._detach_finaliser()
-				sub._detach_finaliser = nil
-			end
-			if bus then bus:_unsubscribe(sub) end
-			self._subs[sub] = nil
-			if sub._conn == self then sub._conn = nil end
-		end
-	end
-
-	local rws = {}
-	for rw in pairs(self._rws) do rws[#rws + 1] = rw end
-	for i = 1, #rws do
-		local rw = rws[i]
-		if rw then
-			rw:_close('disconnected')
-			if rw._detach_finaliser then
-				rw._detach_finaliser()
-				rw._detach_finaliser = nil
-			end
-			if bus then bus:_unwatch_retained(rw) end
-			self._rws[rw] = nil
-			if rw._conn == self then rw._conn = nil end
-		end
-	end
-
-	local eps = {}
-	for ep in pairs(self._eps) do eps[#eps + 1] = ep end
-	for i = 1, #eps do
-		local ep = eps[i]
-		if ep then
-			if ep._tx then ep._tx:close('disconnected') end
-			if bus and bus._endpoints and bus._endpoints[ep._key] == ep then
-				bus._endpoints[ep._key] = nil
-			end
-			if ep._detach_finaliser then
-				ep._detach_finaliser()
-				ep._detach_finaliser = nil
-			end
-			self._eps[ep] = nil
-			if ep._conn == self then ep._conn = nil end
-		end
-	end
-
-	if bus and bus._conns then bus._conns[self] = nil end
-	return true
-end
-
-function Connection:stats()
-	local nsubs, neps, nrws = 0, 0, 0
-	for _ in pairs(self._subs) do nsubs = nsubs + 1 end
-	for _ in pairs(self._eps) do neps = neps + 1 end
-	for _ in pairs(self._rws) do nrws = nrws + 1 end
-	return {
-		dropped         = self:dropped(),
-		subscriptions   = nsubs,
-		endpoints       = neps,
-		retained_watches = nrws,
-	}
-end
-
---------------------------------------------------------------------------------
--- Request helpers (lane A)
---------------------------------------------------------------------------------
-
-function Connection:request_sub(topic, payload, opts)
-	assert_connected(self, 1)
-	assert_topic(topic, 'topic', 1)
-
-	opts = opts or {}
-	if type(opts) ~= 'table' then
-		error('request_sub: opts must be a table (or nil)', 2)
-	end
-
-	assert_authorized(self, 'request', topic, {
-		payload = payload,
-		opts    = opts,
-	}, 1)
-
-	local reply_to = { uuid.new() }
-	local msg      = new_msg(topic, payload, reply_to)
-
-	local sub = self:_subscribe_internal(reply_to, opts)
-	self._bus:_publish(msg)
-	return sub
-end
-
-function Connection:request_once_op(topic, payload, opts)
-	opts = opts or {}
-	if type(opts) ~= 'table' then
-		error('request_once_op: opts must be a table (or nil)', 2)
-	end
-
-	return op.guard(function ()
-		assert_connected(self, 1)
-		assert_topic(topic, 'topic', 1)
-
-		assert_authorized(self, 'request', topic, {
-			payload = payload,
-			opts    = opts,
-		}, 1)
-
-		local reply_to = { uuid.new() }
-		local msg      = new_msg(topic, payload, reply_to)
-
-		return op.bracket(
-			function ()
-				return self:_subscribe_internal(reply_to, { queue_len = 1, full = 'reject_newest' })
-			end,
-			function (sub) sub:unsubscribe() end,
-			function (sub)
-				self._bus:_publish(msg)
-				return sub:recv_op()
-			end
-		)
-	end)
-end
-
---------------------------------------------------------------------------------
--- Lane B: endpoints + publish_one + call_op (opt-in)
---------------------------------------------------------------------------------
-
 ---@param topic Topic
 ---@param opts? table
 ---@return Endpoint
@@ -1074,49 +1021,29 @@ function Connection:unbind(ep)
 	return true
 end
 
-function Connection:publish_one_op(topic, payload, opts)
-	opts = opts or {}
-	if type(opts) ~= 'table' then
-		error('publish_one_op: opts must be a table (or nil)', 2)
+local function call_result_op(reply_rx, reply_tx, deadline)
+	local now = runtime.now()
+	if deadline <= now then
+		reply_tx:close('timeout')
+		return op.always(nil, 'timeout')
 	end
 
-	return op.guard(function ()
-		assert_connected(self, 1)
-		assert_topic(topic, 'topic', 1)
-
-		assert_authorized(self, 'publish_one', topic, {
-			payload  = payload,
-			reply_to = opts.reply_to,
-			id       = opts.id,
-		}, 1)
-
-		local bus = assert(self._bus)
-		assert_concrete_topic(bus._s_wild, bus._m_wild, topic, 'publish_one topic', 2)
-
-		local reply_to = opts.reply_to
-		if reply_to ~= nil then
-			assert_topic(reply_to, 'reply_to', 2)
-			assert_concrete_topic(bus._s_wild, bus._m_wild, reply_to, 'reply_to', 2)
-		end
-
-		local key = topic_key(topic)
-		local ep  = bus._endpoints[key]
-		if not ep or not ep._tx then
-			return op.always(false, 'no_route')
-		end
-
-		local msg = new_msg(topic, payload, reply_to, opts.id)
-
-		return ep._tx:send_op(msg):wrap(function (ok, reason)
-			if ok == true then return true, nil end
-			if ok == nil then return false, 'closed' end
-			return false, reason or 'full'
-		end)
+	local timeout_ev = sleep.sleep_op(deadline - now):wrap(function ()
+		reply_tx:close('timeout')
+		return nil, 'timeout'
 	end)
-end
 
-function Connection:publish_one(topic, payload, opts)
-	return perform(self:publish_one_op(topic, payload, opts))
+	local reply_ev = reply_rx:recv_op():wrap(function (reply)
+		if reply == nil then
+			return nil, tostring(reply_rx:why() or 'closed')
+		end
+		if reply.ok then
+			return reply.value, nil
+		end
+		return nil, reply.err
+	end)
+
+	return op.choice(reply_ev, timeout_ev)
 end
 
 function Connection:call_op(topic, payload, opts)
@@ -1137,162 +1064,51 @@ function Connection:call_op(topic, payload, opts)
 		local bus = assert(self._bus)
 		assert_concrete_topic(bus._s_wild, bus._m_wild, topic, 'call topic', 2)
 
-		local timeout     = (type(opts.timeout) == 'number') and opts.timeout or 1.0
-		local deadline    = (type(opts.deadline) == 'number') and opts.deadline or (runtime.now() + timeout)
-		local backoff     = (type(opts.backoff) == 'number') and opts.backoff or 0.01
-		local backoff_max = (type(opts.backoff_max) == 'number') and opts.backoff_max or 0.2
+		local key = topic_key(topic)
+		local ep  = bus._endpoints[key]
+		if not ep or not ep._tx then
+			return op.always(nil, 'no_route')
+		end
 
-		local request_id  = (opts.request_id ~= nil) and opts.request_id or uuid.new()
-		local reply_topic = { request_id }
+		local timeout  = (type(opts.timeout) == 'number') and opts.timeout or 1.0
+		local deadline = (type(opts.deadline) == 'number') and opts.deadline or (runtime.now() + timeout)
+		local origin   = build_origin(self, opts.origin)
 
 		return op.bracket(
 			function ()
-				return self:_bind_internal(reply_topic, { queue_len = 1 })
+				local reply_tx, reply_rx = mailbox.new(1, { full = 'reject_newest' })
+				local req = new_request(topic, payload, origin, reply_tx)
+
+				local send_op = ep._tx:send_op(req)
+				local ready, ok, reason = send_op.try_fn()
+				assert(ready, 'endpoint admission unexpectedly blocked')
+
+				if ok ~= true then
+					reply_tx:close(reason or 'closed')
+					return {
+						accepted = false,
+						err      = (ok == nil) and 'closed' or (reason or 'full'),
+						reply_tx = reply_tx,
+						reply_rx = reply_rx,
+					}
+				end
+
+				return {
+					accepted = true,
+					reply_tx = reply_tx,
+					reply_rx = reply_rx,
+				}
 			end,
-			function (rep_ep)
-				if rep_ep then pcall(function () rep_ep:unbind() end) end
+			function (res)
+				if res and res.reply_tx then
+					res.reply_tx:close('done')
+				end
 			end,
-			function (rep_ep)
-				local phase    = 'publish'
-				local next_try = runtime.now()
-				local b        = backoff
-
-				local callee_key = topic_key(topic)
-
-				local function reply_buffered()
-					local rx = rep_ep and rep_ep._rx
-					local st = rx and rx._st
-					local buf = st and st.buf
-					return (buf and buf:length() > 0) or false
+			function (res)
+				if not res.accepted then
+					return op.always(nil, res.err)
 				end
-
-				local function reply_closed()
-					local rx = rep_ep and rep_ep._rx
-					local st = rx and rx._st
-					return (not st) or st.closed or false
-				end
-
-				local function try_publish_once()
-					local ep = bus._endpoints and bus._endpoints[callee_key] or nil
-					if not ep or not ep._tx then
-						return false, 'no_route'
-					end
-
-					local msg = new_msg(topic, payload, reply_topic, request_id)
-
-					local send_op = ep._tx:send_op(msg)
-					local r1, r2, r3 = send_op.try_fn()
-
-					if not r1 then
-						return false, 'would_block'
-					end
-					if r2 == true then return true, nil end
-					if r2 == nil then return false, 'closed' end
-					return false, r3 or 'full'
-				end
-
-				local function try_recv_reply()
-					local rxop = rep_ep._rx:recv_op()
-					local ready, v = rxop.try_fn()
-					if not ready then
-						return false, nil, nil
-					end
-					if v == nil then
-						return true, nil, 'closed'
-					end
-					return true, v.payload, nil
-				end
-
-				local function probe_step()
-					local now = runtime.now()
-					if now >= deadline then
-						return true, function () return nil, 'timeout' end
-					end
-
-					if phase == 'wait_reply' and reply_buffered() then
-						return false, 'run'
-					end
-
-					if phase == 'wait_reply' and reply_closed() and not reply_buffered() then
-						return true, function () return nil, 'closed' end
-					end
-
-					if phase == 'publish' then
-						if now >= next_try then
-							return false, 'run'
-						end
-						return false, 'timer'
-					end
-
-					return false, 'any'
-				end
-
-				local function run_step()
-					local now = runtime.now()
-					if now >= deadline then
-						return true, function () return nil, 'timeout' end
-					end
-
-					if phase == 'publish' then
-						if now < next_try then
-							return false, 'timer'
-						end
-
-						local ok_pub, reason = try_publish_once()
-						if ok_pub then
-							phase = 'wait_reply'
-						else
-							if reason ~= 'full' and reason ~= 'no_route' and reason ~= 'closed' then
-								return true, function () return nil, tostring(reason) end
-							end
-
-							local remaining = deadline - runtime.now()
-							local dt = math.min(b, backoff_max, remaining)
-							if dt <= 0 then
-								return true, function () return nil, 'timeout' end
-							end
-
-							next_try = runtime.now() + dt
-							b = math.min(b * 2, backoff_max)
-							return false, 'timer'
-						end
-					end
-
-					local have, payload_out, err = try_recv_reply()
-					if have then
-						if err ~= nil then
-							return true, function () return nil, err end
-						end
-						return true, function () return payload_out, nil end
-					end
-
-					return false, 'any'
-				end
-
-				---@param task Task
-				---@param waker table
-				---@param want any
-				local function register(task, waker, want)
-					waker:at_time(deadline, task)
-
-					if want == 'run' then
-						waker:wakeup(task)
-						return { unlink = function () return false end }
-					end
-
-					if want == 'timer' then
-						waker:at_time(next_try, task)
-						return { unlink = function () return false end }
-					end
-
-					local tok = rep_ep._rx:on_message(task, waker)
-					return tok or { unlink = function () return false end }
-				end
-
-				return wait.waitable2(register, probe_step, run_step)
-					:wrap(function (th)
-						return th()
-					end)
+				return call_result_op(res.reply_rx, res.reply_tx, deadline)
 			end
 		)
 	end)
@@ -1300,6 +1116,80 @@ end
 
 function Connection:call(topic, payload, opts)
 	return perform(self:call_op(topic, payload, opts))
+end
+
+function Connection:disconnect()
+	if self._disconnected then return true end
+	self._disconnected = true
+
+	local bus = self._bus
+	self._bus = nil
+
+	local subs = {}
+	for sub in pairs(self._subs) do subs[#subs + 1] = sub end
+	for i = 1, #subs do
+		local sub = subs[i]
+		if sub then
+			sub:_close('disconnected')
+			if sub._detach_finaliser then
+				sub._detach_finaliser()
+				sub._detach_finaliser = nil
+			end
+			if bus then bus:_unsubscribe(sub) end
+			self._subs[sub] = nil
+			if sub._conn == self then sub._conn = nil end
+		end
+	end
+
+	local rws = {}
+	for rw in pairs(self._rws) do rws[#rws + 1] = rw end
+	for i = 1, #rws do
+		local rw = rws[i]
+		if rw then
+			rw:_close('disconnected')
+			if rw._detach_finaliser then
+				rw._detach_finaliser()
+				rw._detach_finaliser = nil
+			end
+			if bus then bus:_unwatch_retained(rw) end
+			self._rws[rw] = nil
+			if rw._conn == self then rw._conn = nil end
+		end
+	end
+
+	local eps = {}
+	for ep in pairs(self._eps) do eps[#eps + 1] = ep end
+	for i = 1, #eps do
+		local ep = eps[i]
+		if ep then
+			if ep._tx then ep._tx:close('disconnected') end
+			if bus and bus._endpoints and bus._endpoints[ep._key] == ep then
+				bus._endpoints[ep._key] = nil
+			end
+			if ep._detach_finaliser then
+				ep._detach_finaliser()
+				ep._detach_finaliser = nil
+			end
+			self._eps[ep] = nil
+			if ep._conn == self then ep._conn = nil end
+		end
+	end
+
+	if bus and bus._conns then bus._conns[self] = nil end
+	return true
+end
+
+function Connection:stats()
+	local nsubs, neps, nrws = 0, 0, 0
+	for _ in pairs(self._subs) do nsubs = nsubs + 1 end
+	for _ in pairs(self._eps) do neps = neps + 1 end
+	for _ in pairs(self._rws) do nrws = nrws + 1 end
+	return {
+		dropped          = self:dropped(),
+		subscriptions    = nsubs,
+		endpoints        = neps,
+		retained_watches = nrws,
+	}
 end
 
 --------------------------------------------------------------------------------
@@ -1313,19 +1203,20 @@ function Bus:connect(opts)
 	end
 
 	local s = scope_mod.current()
-	local conn = new_connection(self, opts.principal, self._q_length, self._full)
+	local conn = new_connection(self, opts.principal, self._q_length, self._full, opts.origin_base)
 	self._conns[conn] = true
 	s:finally(function () conn:disconnect() end)
 	return conn
 end
 
 function Bus:stats()
-	local connections, dropped = 0, 0
+	local connections, dropped, endpoints = 0, 0, 0
 	local retained_watches = 0
 	for conn in pairs(self._conns) do
 		connections = connections + 1
 		dropped = dropped + conn:dropped()
 		for _ in pairs(conn._rws or {}) do retained_watches = retained_watches + 1 end
+		for _ in pairs(conn._eps or {}) do endpoints = endpoints + 1 end
 	end
 	return {
 		connections      = connections,
@@ -1335,6 +1226,7 @@ function Bus:stats()
 		s_wild           = self._s_wild,
 		m_wild           = self._m_wild,
 		retained_watches = retained_watches,
+		endpoints        = endpoints,
 	}
 end
 
@@ -1381,6 +1273,7 @@ return {
 	RetainedEvent = RetainedEvent,
 	Endpoint      = Endpoint,
 	Message       = Message,
+	Request       = Request,
 
 	-- Re-export trie literal helper for convenience.
 	literal = trie.literal,

--- a/src/bus.lua
+++ b/src/bus.lua
@@ -881,7 +881,7 @@ function RetainedView:changed_op(last_seen)
 		return op.always(nil, why)
 	end
 
-	if self._version ~= last_seen then
+	if self._version > last_seen then
 		return op.always(self._version, nil)
 	end
 
@@ -895,20 +895,21 @@ function RetainedView:changed_op(last_seen)
 	end)
 end
 
-function RetainedView:get(topic)
-	assert_topic(topic, 'topic', 2)
-	return self._items[topic_key(topic)]
+local function copy_msg(msg)
+	if not msg then return nil end
+	return new_msg(msg.topic, msg.payload, msg.origin)
 end
 
---- Return a deterministic array of retained Message objects in this view.
----
---- This deliberately does not expose the bus's internal topic_key() map.
----@return Message[]
+function RetainedView:get(topic)
+	assert_topic(topic, 'topic', 2)
+	return copy_msg(self._items[topic_key(topic)])
+end
+
 function RetainedView:snapshot()
 	local out = {}
 
 	for _, msg in pairs(self._items) do
-		out[#out + 1] = msg
+		out[#out + 1] = copy_msg(msg)
 	end
 
 	table.sort(out, function (a, b)

--- a/src/bus.lua
+++ b/src/bus.lua
@@ -857,17 +857,41 @@ function RetainedView:closed_op()
 	end)
 end
 
+--- Wait until the retained view changes from last_seen, or closes.
+---
+--- Return shape:
+---   changed: version, nil
+---   closed : nil, reason
+---@param last_seen integer
+---@return Op
 function RetainedView:changed_op(last_seen)
 	if type(last_seen) ~= 'number' or last_seen % 1 ~= 0 then
 		error('retained_view.changed_op: last_seen must be an integer', 2)
 	end
 
+	local function close_reason()
+		if self._closed_reason ~= nil then
+			return tostring(self._closed_reason)
+		end
+		return nil
+	end
+
+	local why = close_reason()
+	if why ~= nil then
+		return op.always(nil, why)
+	end
+
 	if self._version ~= last_seen then
-		return op.always(self._version)
+		return op.always(self._version, nil)
 	end
 
 	return self._changed:wait_op():wrap(function ()
-		return self._version
+		local reason = close_reason()
+		if reason ~= nil then
+			return nil, reason
+		end
+
+		return self._version, nil
 	end)
 end
 
@@ -876,11 +900,21 @@ function RetainedView:get(topic)
 	return self._items[topic_key(topic)]
 end
 
+--- Return a deterministic array of retained Message objects in this view.
+---
+--- This deliberately does not expose the bus's internal topic_key() map.
+---@return Message[]
 function RetainedView:snapshot()
 	local out = {}
-	for k, msg in pairs(self._items) do
-		out[k] = msg
+
+	for _, msg in pairs(self._items) do
+		out[#out + 1] = msg
 	end
+
+	table.sort(out, function (a, b)
+		return topic_key(a.topic) < topic_key(b.topic)
+	end)
+
 	return out
 end
 

--- a/src/bus.lua
+++ b/src/bus.lua
@@ -892,8 +892,12 @@ local function copy_msg(msg)
 end
 
 function RetainedView:get(topic)
-	assert_topic(topic, 'topic', 2)
-	return copy_msg(self._items[topic_key(topic)])
+  assert_topic(topic, 'topic', 2)
+  local bus = self._bus or (self._conn and self._conn._bus)
+  if bus then
+    assert_concrete_topic(bus._s_wild, bus._m_wild, topic, 'retained_view:get topic', 2)
+  end
+  return copy_msg(self._items[topic_key(topic)])
 end
 
 function RetainedView:snapshot()

--- a/src/bus.lua
+++ b/src/bus.lua
@@ -771,18 +771,9 @@ local function retained_view_bump(self)
 end
 
 local function retained_view_set_msg(self, msg)
-	local key = topic_key(msg.topic)
-	local old = self._items[key]
-
-	if old
-		and old.payload == msg.payload
-		and old.origin == msg.origin
-	then
-		return
-	end
-
-	self._items[key] = new_msg(msg.topic, msg.payload, msg.origin)
-	retained_view_bump(self)
+  local key = topic_key(msg.topic)
+  self._items[key] = new_msg(msg.topic, msg.payload, msg.origin)
+  retained_view_bump(self)
 end
 
 local function retained_view_delete_topic(self, topic)

--- a/src/bus.lua
+++ b/src/bus.lua
@@ -471,6 +471,7 @@ end
 ---@field origin Origin
 ---@field _cond Cond
 ---@field _done boolean
+---@field _status string
 ---@field _ok boolean|nil
 ---@field _value any
 ---@field _err any
@@ -488,6 +489,7 @@ local function new_request(topic, payload, origin)
 		origin  = origin,
 		_cond   = cond.new(),
 		_done   = false,
+		_status = 'pending',
 		_ok     = nil,
 		_value  = nil,
 		_err    = nil,
@@ -499,8 +501,9 @@ end
 function Request:reply(value)
 	if self._done then return false end
 
-	self._done  = true
-	self._ok    = true
+	self._done   = true
+	self._status = 'replied'
+	self._ok     = true
 	self._value = value
 	self._err   = nil
 	self._cond:signal()
@@ -513,10 +516,11 @@ end
 function Request:fail(err)
 	if self._done then return false end
 
-	self._done  = true
-	self._ok    = false
-	self._value = nil
-	self._err   = err
+	self._done   = true
+	self._status = 'failed'
+	self._ok     = false
+	self._value  = nil
+	self._err    = err
 	self._cond:signal()
 
 	return true
@@ -527,10 +531,11 @@ end
 function Request:abandon(reason)
 	if self._done then return false end
 
-	self._done  = true
-	self._ok    = false
-	self._value = nil
-	self._err   = reason or 'abandoned'
+	self._done   = true
+	self._status = 'abandoned'
+	self._ok     = false
+	self._value  = nil
+	self._err    = reason or 'abandoned'
 	self._cond:signal()
 
 	return true
@@ -539,6 +544,24 @@ end
 ---@return boolean
 function Request:done()
 	return self._done
+end
+
+---@return string status
+---@return any value
+---@return any err
+function Request:status()
+	return self._status or 'pending', self._value, self._err
+end
+
+---@return Op
+function Request:done_op()
+	if self._done then
+		return op.always(self:status())
+	end
+
+	return self._cond:wait_op():wrap(function ()
+		return self:status()
+	end)
 end
 
 ---@return Op
@@ -1389,6 +1412,10 @@ local function call_result_op(req, deadline)
 		return req:wait_reply_op()
 	end
 
+	if deadline == false then
+		return req:wait_reply_op()
+	end
+
 	local now = runtime.now()
 	if deadline <= now then
 		req:abandon('timeout')
@@ -1425,9 +1452,10 @@ function Connection:call_op(topic, payload, opts)
 			return op.always(nil, 'no_route')
 		end
 
-		local timeout  = (type(opts.timeout) == 'number') and opts.timeout or 1.0
-		local deadline = (type(opts.deadline) == 'number') and opts.deadline or (runtime.now() + timeout)
-		local req      = new_request(topic, payload, build_origin(self, opts.extra))
+		local no_timeout = opts.timeout == false or opts.deadline == false
+		local timeout    = (type(opts.timeout) == 'number') and opts.timeout or 1.0
+		local deadline   = no_timeout and false or ((type(opts.deadline) == 'number') and opts.deadline or (runtime.now() + timeout))
+		local req        = new_request(topic, payload, build_origin(self, opts.extra))
 
 		local ok, reason = mailbox_try_send(ep._tx, req)
 		if ok ~= true then

--- a/src/bus.lua
+++ b/src/bus.lua
@@ -10,6 +10,7 @@
 --   * wildcard subscriptions (pubsub trie: wildcards allowed in stored keys; literal queries)
 --   * retained messages (retained trie: literal stored keys; wildcards allowed in queries)
 --   * retained watch feeds (wildcard watch patterns over retain/unretain lifecycle)
+--   * retained materialised views for event-driven assertions/observation
 --   * bounded endpoint calls with native request/reply (no public reply topics)
 --   * immutable origin metadata attached to delivered bus objects
 --   * trusted provenance is bus-owned; callers may attach only origin.extra
@@ -131,6 +132,7 @@ end
 local function assert_concrete_topic(s_wild, m_wild, topic, what, level)
 	level = (level or 1) + 1
 	local n = array_len(topic, level)
+
 	for i = 1, n do
 		local raw, was_lit = unwrap_token(topic[i])
 		if not was_lit and (raw == s_wild or raw == m_wild) then
@@ -144,6 +146,7 @@ end
 local function topic_key(topic)
 	local n = array_len(topic, 3)
 	local parts = {}
+
 	for i = 1, n do
 		local raw = unwrap_token(topic[i])
 		if type(raw) == 'string' then
@@ -153,6 +156,7 @@ local function topic_key(topic)
 			parts[#parts + 1] = 'n' .. #s .. ':' .. s
 		end
 	end
+
 	return table.concat(parts, '|')
 end
 
@@ -161,22 +165,29 @@ end
 local function topic_debug(topic)
 	local n = array_len(topic, 3)
 	local parts = {}
+
 	for i = 1, n do
 		local raw, was_lit = unwrap_token(topic[i])
 		parts[i] = was_lit and ('=' .. tostring(raw)) or tostring(raw)
 	end
+
 	return table.concat(parts, '/')
 end
 
 local function copy_table(t)
 	local out = {}
 	if not t then return out end
-	for k, v in pairs(t) do out[k] = v end
+
+	for k, v in pairs(t) do
+		out[k] = v
+	end
+
 	return out
 end
 
 local function freeze_shallow(t, err)
 	local data = t or {}
+
 	return setmetatable({}, {
 		__index     = data,
 		__newindex  = function () error(err or 'table is immutable', 2) end,
@@ -192,7 +203,9 @@ end
 local function mailbox_try_send(tx, value)
 	local send_op = tx:send_op(value)
 	local ready, ok, reason = send_op.try_fn()
+
 	assert(ready, 'bus mailbox unexpectedly blocked')
+
 	if ok == true then return true, nil end
 	if ok == nil then return nil, reason or 'closed' end
 	return false, reason or 'full'
@@ -209,6 +222,7 @@ local function deliver_required_or_close(tx, value, close_reason)
 	if ok == true then
 		return true
 	end
+
 	tx:close(close_reason or reason or 'closed')
 	return false
 end
@@ -217,22 +231,27 @@ local function require_opts_table(name, opts, level)
 	if opts ~= nil and type(opts) ~= 'table' then
 		error(name .. ': opts must be a table (or nil)', (level or 1) + 1)
 	end
+
 	return opts or {}
 end
 
 local function resolve_queue_len(opts, default_len, name, level)
 	local qlen = opts.queue_len
 	if qlen == nil then qlen = default_len end
+
 	if type(qlen) ~= 'number' or qlen < 0 then
 		error(name .. ': queue_len must be >= 0', (level or 1) + 1)
 	end
+
 	return qlen
 end
 
 local function resolve_feed_opts(opts, default_len, default_full, name, level)
 	opts = require_opts_table(name, opts, (level or 1) + 1)
+
 	local qlen = resolve_queue_len(opts, default_len, name, (level or 1) + 1)
 	local full = assert_full_policy(opts.full or default_full, (level or 1) + 1) or DEFAULT_POLICY
+
 	return opts, qlen, full
 end
 
@@ -278,6 +297,7 @@ local function trusted_origin_base(conn)
 	if type(src) == 'function' then
 		src = src() or {}
 	end
+
 	return copy_table(src)
 end
 
@@ -286,12 +306,16 @@ end
 ---@return Origin
 local function build_origin(conn, extra)
 	local out = trusted_origin_base(conn)
+
 	if out.kind == nil then out.kind = 'local' end
+
 	out.conn_id   = conn._conn_id
 	out.principal = conn._principal
+
 	if type(extra) == 'table' and next(extra) ~= nil then
 		out.extra = freeze_shallow(copy_table(extra), 'origin.extra is immutable')
 	end
+
 	return freeze_shallow(out, 'origin is immutable')
 end
 
@@ -303,23 +327,27 @@ end
 ---@return function|nil
 local function authoriser_callable(auth)
 	if auth == nil then return nil end
+
 	if type(auth) == 'function' then
 		return function(ctx)
 			return auth(ctx)
 		end
 	end
+
 	if type(auth) == 'table' then
 		if type(auth.allow) == 'function' then
 			return function(ctx)
 				return auth:allow(ctx)
 			end
 		end
+
 		if type(auth.authorize) == 'function' then
 			return function(ctx)
 				return auth:authorize(ctx)
 			end
 		end
 	end
+
 	return nil
 end
 
@@ -350,6 +378,7 @@ local function authorize_action(bus, principal, action, topic, extra, level)
 	if ok == false or ok == nil then
 		return false, reason or 'forbidden'
 	end
+
 	return true, nil
 end
 
@@ -360,6 +389,7 @@ end
 ---@param level? integer
 local function assert_authorized(self, action, topic, extra, level)
 	level = (level or 1) + 1
+
 	local ok, reason = authorize_action(self._bus, self._principal, action, topic, extra, level)
 	if not ok then
 		error(
@@ -468,11 +498,13 @@ end
 ---@return boolean ok
 function Request:reply(value)
 	if self._done then return false end
+
 	self._done  = true
 	self._ok    = true
 	self._value = value
 	self._err   = nil
 	self._cond:signal()
+
 	return true
 end
 
@@ -480,11 +512,13 @@ end
 ---@return boolean ok
 function Request:fail(err)
 	if self._done then return false end
+
 	self._done  = true
 	self._ok    = false
 	self._value = nil
 	self._err   = err
 	self._cond:signal()
+
 	return true
 end
 
@@ -492,11 +526,13 @@ end
 ---@return boolean ok
 function Request:abandon(reason)
 	if self._done then return false end
+
 	self._done  = true
 	self._ok    = false
 	self._value = nil
 	self._err   = reason or 'abandoned'
 	self._cond:signal()
+
 	return true
 end
 
@@ -511,6 +547,7 @@ function Request:wait_reply_op()
 		if self._ok then
 			return op.always(self._value, nil)
 		end
+
 		return op.always(nil, self._err)
 	end
 
@@ -518,6 +555,7 @@ function Request:wait_reply_op()
 		if self._ok then
 			return self._value, nil
 		end
+
 		return nil, self._err
 	end)
 end
@@ -526,8 +564,58 @@ end
 -- Common feed-handle behaviour
 --------------------------------------------------------------------------------
 
+---@class Feed
 local Feed = {}
 Feed.__index = Feed
+
+---@class Subscription : Feed
+local Subscription = {}
+Subscription.__index = Subscription
+setmetatable(Subscription, { __index = Feed })
+
+---@class RetainedWatch : Feed
+local RetainedWatch = {}
+RetainedWatch.__index = RetainedWatch
+setmetatable(RetainedWatch, { __index = Feed })
+
+---@class Endpoint : Feed
+local Endpoint = {}
+Endpoint.__index = Endpoint
+setmetatable(Endpoint, { __index = Feed })
+
+local function new_feed(mt, conn, kind, topic, tx, rx, extra)
+	local obj = {
+		_conn             = conn,
+		_kind             = kind,
+		_topic            = topic,
+		_tx               = tx,
+		_rx               = rx,
+		_closed           = cond.new(),
+		_detach_finaliser = nil,
+	}
+
+	if extra then
+		for k, v in pairs(extra) do obj[k] = v end
+	end
+
+	return setmetatable(obj, mt)
+end
+
+local function new_subscription(conn, topic, tx, rx)
+	return new_feed(Subscription, conn, 'subscription', topic, tx, rx)
+end
+
+local function new_retained_watch(conn, topic, tx, rx)
+	return new_feed(RetainedWatch, conn, 'retained_watch', topic, tx, rx)
+end
+
+local function new_endpoint(conn, topic, key, tx, rx)
+	return new_feed(Endpoint, conn, 'endpoint', topic, tx, rx, { _key = key })
+end
+
+function Feed:kind()
+	return self._kind
+end
 
 function Feed:topic()
 	return self._topic
@@ -545,6 +633,19 @@ end
 ---@param reason any
 function Feed:_close(reason)
 	if self._tx then self._tx:close(reason) end
+	if self._closed then self._closed:signal() end
+end
+
+---@return Op
+function Feed:closed_op()
+	local why = self:why()
+	if why ~= nil then
+		return op.always(tostring(why))
+	end
+
+	return self._closed:wait_op():wrap(function ()
+		return tostring(self:why() or 'closed')
+	end)
 end
 
 ---@return Op
@@ -553,6 +654,7 @@ function Feed:recv_op()
 		if item == nil then
 			return nil, tostring(self._rx:why() or 'closed')
 		end
+
 		return item, nil
 	end)
 end
@@ -565,43 +667,11 @@ function Feed:iter()
 	return self._rx:iter()
 end
 
-local function new_feed(mt, conn, topic, tx, rx, extra)
-	local obj = {
-		_conn             = conn,
-		_topic            = topic,
-		_tx               = tx,
-		_rx               = rx,
-		_detach_finaliser = nil,
-	}
-	if extra then
-		for k, v in pairs(extra) do obj[k] = v end
+function Feed:payloads()
+	if getmetatable(self) ~= Subscription then
+		error('payloads expects a Subscription', 2)
 	end
-	return setmetatable(obj, mt)
-end
 
---------------------------------------------------------------------------------
--- Subscription (state/event plane)
---------------------------------------------------------------------------------
-
----@class Subscription : Feed
-local Subscription = {}
-Subscription.__index = Subscription
-setmetatable(Subscription, { __index = Feed })
-
-local function new_subscription(conn, topic, tx, rx)
-	return new_feed(Subscription, conn, topic, tx, rx)
-end
-
-function Subscription:unsubscribe()
-	local conn = self._conn
-	if not conn then
-		self:_close('unsubscribed')
-		return true
-	end
-	return conn:unsubscribe(self)
-end
-
-function Subscription:payloads()
 	local it = self._rx:iter()
 	return function ()
 		local msg = it()
@@ -609,62 +679,213 @@ function Subscription:payloads()
 	end
 end
 
-function Subscription:stats()
+function Feed:stats()
 	return {
 		dropped = self:dropped(),
 		topic   = self._topic,
+		kind    = self._kind,
 	}
 end
 
---------------------------------------------------------------------------------
--- Retained watch feed
---------------------------------------------------------------------------------
-
----@class RetainedWatch : Feed
-local RetainedWatch = {}
-RetainedWatch.__index = RetainedWatch
-setmetatable(RetainedWatch, { __index = Feed })
-
-local function new_retained_watch(conn, topic, tx, rx)
-	return new_feed(RetainedWatch, conn, topic, tx, rx)
-end
-
-function RetainedWatch:unwatch()
+function Feed:close()
 	local conn = self._conn
 	if not conn then
-		self:_close('unwatched')
+		self:_close(self._kind == 'endpoint' and 'unbound' or 'closed')
 		return true
 	end
-	return conn:unwatch_retained(self)
+
+	if getmetatable(self) == Subscription then
+		return conn:unsubscribe(self)
+	elseif getmetatable(self) == RetainedWatch then
+		return conn:unwatch_retained(self)
+	elseif getmetatable(self) == Endpoint then
+		return conn:unbind(self)
+	end
+
+	error('unknown feed kind: ' .. tostring(self._kind), 2)
 end
 
-function RetainedWatch:stats()
-	return {
-		dropped = self:dropped(),
-		topic   = self._topic,
-	}
+function Feed:unsubscribe()
+	if getmetatable(self) ~= Subscription then
+		error('unsubscribe expects a Subscription', 2)
+	end
+
+	return self:close()
+end
+
+function Feed:unwatch()
+	if getmetatable(self) ~= RetainedWatch then
+		error('unwatch expects a RetainedWatch', 2)
+	end
+
+	return self:close()
+end
+
+function Feed:unbind()
+	if getmetatable(self) ~= Endpoint then
+		error('unbind expects an Endpoint', 2)
+	end
+
+	return self:close()
 end
 
 --------------------------------------------------------------------------------
--- Endpoint (command plane)
+-- Retained materialised view
 --------------------------------------------------------------------------------
 
----@class Endpoint : Feed
-local Endpoint = {}
-Endpoint.__index = Endpoint
-setmetatable(Endpoint, { __index = Feed })
+---@class RetainedView
+---@field _conn Connection|nil
+---@field _bus Bus|nil
+---@field _topic Topic
+---@field _items table<string, Message>
+---@field _version integer
+---@field _changed Cond
+---@field _closed Cond
+---@field _closed_reason any
+---@field _detach_finaliser function|nil
+local RetainedView = {}
+RetainedView.__index = RetainedView
 
-local function new_endpoint(conn, topic, key, tx, rx)
-	return new_feed(Endpoint, conn, topic, tx, rx, { _key = key })
+local function new_retained_view(conn, topic)
+	return setmetatable({
+		_conn             = conn,
+		_bus              = conn._bus,
+		_topic            = topic,
+		_items            = {},
+		_version          = 0,
+		_changed          = cond.new(),
+		_closed           = cond.new(),
+		_closed_reason    = nil,
+		_detach_finaliser = nil,
+	}, RetainedView)
 end
 
-function Endpoint:unbind()
+function RetainedView:version()
+	return self._version
+end
+
+local function retained_view_bump(self)
+	self._version = self._version + 1
+	self._changed:signal()
+	self._changed = cond.new()
+end
+
+local function retained_view_set_msg(self, msg)
+	local key = topic_key(msg.topic)
+	local old = self._items[key]
+
+	if old
+		and old.payload == msg.payload
+		and old.origin == msg.origin
+	then
+		return
+	end
+
+	self._items[key] = new_msg(msg.topic, msg.payload, msg.origin)
+	retained_view_bump(self)
+end
+
+local function retained_view_delete_topic(self, topic)
+	local key = topic_key(topic)
+
+	if self._items[key] == nil then
+		return
+	end
+
+	self._items[key] = nil
+	retained_view_bump(self)
+end
+
+function RetainedView:_ingest(ev)
+	if self._closed_reason ~= nil then
+		return
+	end
+
+	if ev.op == 'retain' then
+		retained_view_set_msg(self, {
+			topic   = ev.topic,
+			payload = ev.payload,
+			origin  = ev.origin,
+		})
+	elseif ev.op == 'unretain' then
+		retained_view_delete_topic(self, ev.topic)
+	elseif ev.op == 'replay_done' then
+		-- Materialised views are kept directly by the bus. Replay markers are
+		-- feed-only events and do not affect the view.
+	else
+		-- Future-proof: ignore unknown retained lifecycle events.
+	end
+end
+
+function RetainedView:_close(reason)
+	if self._closed_reason ~= nil then return end
+
+	self._closed_reason = reason or 'closed'
+
+	local bus = self._bus
+	self._bus = nil
+
+	if bus then
+		bus:_remove_retained_view(self)
+	end
+
 	local conn = self._conn
-	if not conn then
-		if self._tx then self._tx:close('unbound') end
-		return true
+	self._conn = nil
+
+	if conn and conn._views then
+		conn._views[self] = nil
 	end
-	return conn:unbind(self)
+
+	clear_finaliser(self)
+
+	retained_view_bump(self)
+	self._closed:signal()
+end
+
+function RetainedView:close()
+	self:_close('closed')
+	return true
+end
+
+function RetainedView:closed_op()
+	if self._closed_reason ~= nil then
+		return op.always(tostring(self._closed_reason))
+	end
+
+	return self._closed:wait_op():wrap(function ()
+		return tostring(self._closed_reason or 'closed')
+	end)
+end
+
+function RetainedView:changed_op(last_seen)
+	if type(last_seen) ~= 'number' or last_seen % 1 ~= 0 then
+		error('retained_view.changed_op: last_seen must be an integer', 2)
+	end
+
+	if self._version ~= last_seen then
+		return op.always(self._version)
+	end
+
+	return self._changed:wait_op():wrap(function ()
+		return self._version
+	end)
+end
+
+function RetainedView:get(topic)
+	assert_topic(topic, 'topic', 2)
+	return self._items[topic_key(topic)]
+end
+
+function RetainedView:snapshot()
+	local out = {}
+	for k, msg in pairs(self._items) do
+		out[k] = msg
+	end
+	return out
+end
+
+function RetainedView:items()
+	return self:snapshot()
 end
 
 --------------------------------------------------------------------------------
@@ -677,6 +898,7 @@ end
 ---@field _topics any
 ---@field _retained any
 ---@field _retained_watchers any
+---@field _retained_views any
 ---@field _conns table<Connection, boolean>
 ---@field _s_wild string|number
 ---@field _m_wild string|number
@@ -711,7 +933,9 @@ end
 function Bus:_unsubscribe(sub)
 	local subs = self._topics:retrieve(sub._topic)
 	if not subs then return end
+
 	subs[sub] = nil
+
 	if next(subs) == nil then
 		self._topics:delete(sub._topic)
 	end
@@ -737,15 +961,54 @@ function Bus:_notify_retained(ev)
 	end)
 end
 
+function Bus:_add_retained_view(view)
+	local views = self._retained_views:retrieve(view._topic)
+	if not views then
+		views = {}
+		self._retained_views:insert(view._topic, views)
+	end
+
+	views[view] = true
+
+	self._retained:each(view._topic, function (_k, retained_msg)
+		retained_view_set_msg(view, retained_msg)
+	end)
+end
+
+function Bus:_remove_retained_view(view)
+	local views = self._retained_views:retrieve(view._topic)
+	if not views then return end
+
+	views[view] = nil
+
+	if next(views) == nil then
+		self._retained_views:delete(view._topic)
+	end
+end
+
+function Bus:_notify_retained_views(ev)
+	self._retained_views:each(ev.topic, function (_k, views)
+		for view in pairs(views) do
+			view:_ingest(ev)
+		end
+	end)
+end
+
 function Bus:_retain(msg)
 	self:_publish(msg)
 	self._retained:insert(msg.topic, msg)
-	self:_notify_retained(new_retained_event('retain', msg.topic, msg.payload, msg.origin))
+
+	local ev = new_retained_event('retain', msg.topic, msg.payload, msg.origin)
+	self:_notify_retained(ev)
+	self:_notify_retained_views(ev)
 end
 
 function Bus:_unretain(topic, origin)
 	self._retained:delete(topic)
-	self:_notify_retained(new_retained_event('unretain', topic, nil, origin))
+
+	local ev = new_retained_event('unretain', topic, nil, origin)
+	self:_notify_retained(ev)
+	self:_notify_retained_views(ev)
 end
 
 ---@param conn Connection
@@ -772,7 +1035,9 @@ function Bus:_watch_retained(conn, topic, qlen, full, replay)
 		end)
 
 		if not deliver_required_or_close(tx, new_replay_done_event(), 'replay_overflow') then
+			rw:_close('replay_overflow')
 			watchers[rw] = nil
+
 			if next(watchers) == nil then
 				self._retained_watchers:delete(topic)
 			end
@@ -785,7 +1050,9 @@ end
 function Bus:_unwatch_retained(rw)
 	local watchers = self._retained_watchers:retrieve(rw._topic)
 	if not watchers then return end
+
 	watchers[rw] = nil
+
 	if next(watchers) == nil then
 		self._retained_watchers:delete(rw._topic)
 	end
@@ -803,6 +1070,7 @@ end
 ---@field _subs table<Subscription, boolean>
 ---@field _eps table<Endpoint, boolean>
 ---@field _rws table<RetainedWatch, boolean>
+---@field _views table<RetainedView, boolean>
 ---@field _disconnected boolean
 ---@field _conn_id string
 ---@field _origin_factory table|fun():table
@@ -824,6 +1092,7 @@ local function new_connection(bus, principal, q_length, full, origin_factory)
 		_subs           = {},
 		_eps            = {},
 		_rws            = {},
+		_views          = {},
 		_disconnected   = false,
 		_conn_id        = tostring(uuid.new()),
 		_origin_factory = origin_factory or {},
@@ -842,6 +1111,7 @@ end
 ---@return Connection
 function Connection:derive(opts)
 	assert_connected(self, 1)
+
 	opts = require_opts_table('derive', opts, 2)
 
 	local bus = assert(self._bus)
@@ -854,11 +1124,13 @@ end
 
 function Connection:dropped()
 	local n = 0
+
 	for _, set in ipairs({ self._subs, self._eps, self._rws }) do
 		for item in pairs(set) do
 			n = n + (item:dropped() or 0)
 		end
 	end
+
 	return n
 end
 
@@ -866,7 +1138,8 @@ function Connection:publish(topic, payload, opts)
 	assert_connected(self, 1)
 	assert_topic(topic, 'topic', 1)
 
-	opts = opts or {}
+	opts = require_opts_table('publish', opts, 2)
+
 	assert_authorized(self, 'publish', topic, {
 		payload = payload,
 		opts    = opts,
@@ -880,7 +1153,8 @@ function Connection:retain(topic, payload, opts)
 	assert_connected(self, 1)
 	assert_topic(topic, 'topic', 1)
 
-	opts = opts or {}
+	opts = require_opts_table('retain', opts, 2)
+
 	assert_authorized(self, 'retain', topic, {
 		payload = payload,
 		opts    = opts,
@@ -894,7 +1168,8 @@ function Connection:unretain(topic, opts)
 	assert_connected(self, 1)
 	assert_topic(topic, 'topic', 1)
 
-	opts = opts or {}
+	opts = require_opts_table('unretain', opts, 2)
+
 	assert_authorized(self, 'unretain', topic, {
 		opts = opts,
 	}, 1)
@@ -942,7 +1217,9 @@ function Connection:unsubscribe(sub)
 		self._subs[sub] = nil
 		self._bus:_unsubscribe(sub)
 	end
+
 	if sub._conn == self then sub._conn = nil end
+
 	return true
 end
 
@@ -953,6 +1230,7 @@ function Connection:_watch_retained_internal(topic, opts)
 	assert_connected(self, 1)
 
 	opts = require_opts_table('_watch_retained_internal', opts, 2)
+
 	local _, qlen, full = resolve_feed_opts(opts, self._q_length, self._full, '_watch_retained_internal', 2)
 	local replay = not not opts.replay
 	local rw = self._bus:_watch_retained(self, topic, qlen, full, replay)
@@ -987,8 +1265,31 @@ function Connection:unwatch_retained(rw)
 		self._rws[rw] = nil
 		self._bus:_unwatch_retained(rw)
 	end
+
 	if rw._conn == self then rw._conn = nil end
+
 	return true
+end
+
+---@param topic Topic
+---@param opts? table
+---@return RetainedView
+function Connection:retained_view(topic, opts)
+	assert_connected(self, 1)
+	assert_topic(topic, 'topic', 1)
+
+	opts = require_opts_table('retained_view', opts, 2)
+
+	assert_authorized(self, 'watch_retained', topic, {
+		opts = opts,
+	}, 1)
+
+	local view = new_retained_view(self, topic)
+	self._bus:_add_retained_view(view)
+
+	return own_in_scope(self._views, view, function ()
+		view:_close('scope_closed')
+	end)
 end
 
 ---@param topic Topic
@@ -1013,6 +1314,7 @@ function Connection:_bind_internal(topic, opts)
 	local ep     = new_endpoint(self, topic, key, tx, rx)
 
 	bus._endpoints[key] = ep
+
 	return own_in_scope(self._eps, ep, function ()
 		ep:unbind()
 	end)
@@ -1036,17 +1338,19 @@ function Connection:unbind(ep)
 
 	local bus = self._bus
 
-	if ep._tx then ep._tx:close('unbound') end
+	ep:_close('unbound')
 	clear_finaliser(ep)
 
 	if self._eps[ep] then
 		self._eps[ep] = nil
+
 		if bus and bus._endpoints and bus._endpoints[ep._key] == ep then
 			bus._endpoints[ep._key] = nil
 		end
 	end
 
 	if ep._conn == self then ep._conn = nil end
+
 	return true
 end
 
@@ -1086,6 +1390,7 @@ function Connection:call_op(topic, payload, opts)
 
 		local key = topic_key(topic)
 		local ep  = bus._endpoints[key]
+
 		if not ep or not ep._tx then
 			return op.always(nil, 'no_route')
 		end
@@ -1113,6 +1418,7 @@ end
 
 function Connection:disconnect()
 	if self._disconnected then return true end
+
 	self._disconnected = true
 
 	local bus = self._bus
@@ -1121,7 +1427,9 @@ function Connection:disconnect()
 	disconnect_all(self._subs, function (sub)
 		sub:_close('disconnected')
 		clear_finaliser(sub)
+
 		if bus then bus:_unsubscribe(sub) end
+
 		self._subs[sub] = nil
 		if sub._conn == self then sub._conn = nil end
 	end)
@@ -1129,24 +1437,34 @@ function Connection:disconnect()
 	disconnect_all(self._rws, function (rw)
 		rw:_close('disconnected')
 		clear_finaliser(rw)
+
 		if bus then bus:_unwatch_retained(rw) end
+
 		self._rws[rw] = nil
 		if rw._conn == self then rw._conn = nil end
 	end)
 
 	disconnect_all(self._eps, function (ep)
-		if ep._tx then ep._tx:close('disconnected') end
+		ep:_close('disconnected')
+
 		if bus and bus._endpoints and bus._endpoints[ep._key] == ep then
 			bus._endpoints[ep._key] = nil
 		end
+
 		clear_finaliser(ep)
+
 		self._eps[ep] = nil
 		if ep._conn == self then ep._conn = nil end
+	end)
+
+	disconnect_all(self._views, function (view)
+		view:_close('disconnected')
 	end)
 
 	if bus and bus._conns then
 		bus._conns[self] = nil
 	end
+
 	return true
 end
 
@@ -1156,6 +1474,7 @@ function Connection:stats()
 		subscriptions    = count_keys(self._subs),
 		endpoints        = count_keys(self._eps),
 		retained_watches = count_keys(self._rws),
+		retained_views   = count_keys(self._views),
 	}
 end
 
@@ -1171,6 +1490,7 @@ function Bus:connect(opts)
 	local conn = new_connection(self, opts.principal, self._q_length, self._full, origin_factory)
 
 	self._conns[conn] = true
+
 	s:finally(function ()
 		conn:disconnect()
 	end)
@@ -1183,12 +1503,14 @@ function Bus:stats()
 	local dropped          = 0
 	local endpoints        = 0
 	local retained_watches = 0
+	local retained_views   = 0
 
 	for conn in pairs(self._conns) do
 		connections      = connections + 1
 		dropped          = dropped + conn:dropped()
 		endpoints        = endpoints + count_keys(conn._eps or {})
 		retained_watches = retained_watches + count_keys(conn._rws or {})
+		retained_views   = retained_views + count_keys(conn._views or {})
 	end
 
 	return {
@@ -1199,6 +1521,7 @@ function Bus:stats()
 		s_wild           = self._s_wild,
 		m_wild           = self._m_wild,
 		retained_watches = retained_watches,
+		retained_views   = retained_views,
 		endpoints        = endpoints,
 	}
 end
@@ -1214,6 +1537,7 @@ local function new(params)
 
 	local q_length = params.q_length
 	if q_length == nil then q_length = DEFAULT_Q_LEN end
+
 	if type(q_length) ~= 'number' or q_length < 0 then
 		error('bus.new: q_length must be >= 0', 2)
 	end
@@ -1235,6 +1559,7 @@ local function new(params)
 		_topics            = trie.new_pubsub(s_wild, m_wild),
 		_retained          = trie.new_retained(s_wild, m_wild),
 		_retained_watchers = trie.new_pubsub(s_wild, m_wild),
+		_retained_views    = trie.new_pubsub(s_wild, m_wild),
 		_conns             = setmetatable({}, { __mode = 'k' }),
 		_endpoints         = {},
 		_authoriser        = authoriser,
@@ -1248,9 +1573,10 @@ return {
 	Connection    = Connection,
 	Subscription  = Subscription,
 	RetainedWatch = RetainedWatch,
-	RetainedEvent = RetainedEvent,
+	RetainedView  = RetainedView,
 	Endpoint      = Endpoint,
 	Message       = Message,
+	RetainedEvent = RetainedEvent,
 	Request       = Request,
 	Origin        = Origin,
 

--- a/tests/test.lua
+++ b/tests/test.lua
@@ -38,6 +38,20 @@ local function topic_str(topic)
 	return table.concat(parts, '/')
 end
 
+local function assert_local_origin(origin, principal)
+	assert(type(origin) == 'table', 'expected origin table')
+	assert_eq(origin.kind, 'local', 'expected local origin kind')
+	assert(origin.conn_id ~= nil, 'expected conn_id in origin')
+	if principal ~= nil then
+		assert(origin.principal == principal, 'expected origin principal to match')
+	end
+end
+
+local function assert_origin_immutable(origin)
+	local ok = pcall(function () origin.kind = 'mutated' end)
+	assert(not ok, 'expected origin to be immutable')
+end
+
 -- A standard “deadline arm”: returns (nil, 'timeout').
 local function timeout_op(dt)
 	return Sleep.sleep_op(dt):wrap(function ()
@@ -48,25 +62,6 @@ end
 -- Named-choice convenience: returns (winner_name, ...arm_results...)
 local function select_named(arms)
 	return fibers.perform(fibers.named_choice(arms))
-end
-
--- Reply helper for mixed modalities:
--- - If reply_to is a Lane B endpoint, publish_one will deliver.
--- - If reply_to is a Lane A subscription topic, publish_one returns no_route; fall back to publish.
-local function reply_best_effort(conn, reply_to, payload, opts)
-	if not reply_to then return true end
-	opts = opts or {}
-
-	local ok, reason = conn:publish_one(reply_to, payload, opts)
-	if ok then return true end
-
-	if reason == 'no_route' then
-		conn:publish(reply_to, payload, opts)
-		return true
-	end
-
-	-- For tests: surface other failures explicitly.
-	return false, reason
 end
 
 --------------------------------------------------------------------------------
@@ -127,6 +122,8 @@ local function test_simple()
 
 	local msg, err = fibers.perform(sub:recv_op())
 	assert(msg and msg.payload == 'Hello' and err == nil)
+	assert_local_origin(msg.origin)
+	assert_origin_immutable(msg.origin)
 
 	print('Simple test passed!')
 end
@@ -295,6 +292,8 @@ local function test_retained_msg_basic()
 	local sub = conn:subscribe({ 'retained', 'topic' })
 	local msg, err = fibers.perform(sub:recv_op())
 	assert(msg and msg.payload == 'RetainedMessage' and err == nil)
+	assert_local_origin(msg.origin)
+	assert_origin_immutable(msg.origin)
 
 	print('Retained message (basic) test passed!')
 end
@@ -376,6 +375,8 @@ local function test_retained_watch_replay_and_live_changes()
 		assert_eq(ev.op, 'retain')
 		assert_eq(topic_str(ev.topic), 'watch/a')
 		assert_eq(ev.payload, 'A1')
+		assert_local_origin(ev.origin)
+		assert_origin_immutable(ev.origin)
 	end
 
 	conn:retain({ 'watch', 'b' }, 'B1')
@@ -386,6 +387,7 @@ local function test_retained_watch_replay_and_live_changes()
 		assert_eq(ev.op, 'retain')
 		assert_eq(topic_str(ev.topic), 'watch/b')
 		assert_eq(ev.payload, 'B1')
+		assert_local_origin(ev.origin)
 	end
 
 	conn:unretain({ 'watch', 'a' })
@@ -396,6 +398,7 @@ local function test_retained_watch_replay_and_live_changes()
 		assert_eq(ev.op, 'unretain')
 		assert_eq(topic_str(ev.topic), 'watch/a')
 		assert(ev.payload == nil, 'expected nil payload for unretain')
+		assert_local_origin(ev.origin)
 	end
 
 	-- Ordinary publish should not appear on retained watch feeds.
@@ -840,41 +843,37 @@ local function test_laneA_fanout_independent_backpressure()
 end
 
 --------------------------------------------------------------------------------
--- Lane B: endpoints, publish_one admission, and call
+-- Lane B: endpoints and call
 --------------------------------------------------------------------------------
 
-local function test_laneB_publish_one_modalities()
-	local bus  = Bus.new({ m_wild = '#', s_wild = '+' })
-	local conn = bus:connect()
+local function test_laneB_call_full_and_closed_modalities()
+	local bus    = Bus.new({ m_wild = '#', s_wild = '+' })
+	local server = bus:connect()
+	local client = bus:connect()
+
+	local ep = server:bind({ 'svc', 'rzv' }, { queue_len = 0 })
 
 	do
-		local ok, reason = conn:publish_one({ 'svc', 'missing' }, 'x')
-		assert_eq(ok, false)
-		assert_eq(reason, 'no_route')
-	end
-
-	local ep = conn:bind({ 'svc', 'rzv' }, { queue_len = 0 })
-
-	do
-		local ok, reason = conn:publish_one({ 'svc', 'rzv' }, 'x')
-		assert_eq(ok, false)
-		assert_eq(reason, 'full')
+		local reply, err = client:call({ 'svc', 'rzv' }, 'x', { timeout = TMO })
+		assert(reply == nil)
+		assert_eq(err, 'full')
 		assert_eq(ep:dropped(), 1)
 	end
 
 	local got = Channel.new(1)
 	fibers.spawn(function ()
-		local msg, err = ep:recv()
-		assert(msg, tostring(err))
-		got:put(msg.payload)
+		local req, err = ep:recv()
+		assert(req, tostring(err))
+		got:put(req.payload)
+		assert(req:reply('reply:' .. tostring(req.payload)))
 	end)
 
 	Sleep.sleep(TMO)
 
 	do
-		local ok, reason = conn:publish_one({ 'svc', 'rzv' }, 'hello')
-		assert_eq(ok, true)
-		assert(reason == nil)
+		local reply, err = client:call({ 'svc', 'rzv' }, 'hello', { timeout = LONG_TMO })
+		assert(err == nil, tostring(err))
+		assert_eq(reply, 'reply:hello')
 	end
 
 	do
@@ -890,48 +889,54 @@ local function test_laneB_publish_one_modalities()
 	ep._tx:close('manual close')
 
 	do
-		local ok, reason = conn:publish_one({ 'svc', 'rzv' }, 'x')
-		assert_eq(ok, false)
-		assert_eq(reason, 'closed')
+		local reply, err = client:call({ 'svc', 'rzv' }, 'x', { timeout = TMO })
+		assert(reply == nil)
+		assert_eq(err, 'closed')
 	end
 
-	print('Lane B publish_one modalities test passed!')
+	print('Lane B call full/closed modalities test passed!')
 end
 
 local function test_laneB_concrete_topic_enforcement_and_literal_ok()
-	local bus  = Bus.new({ m_wild = '#', s_wild = '+' })
-	local conn = bus:connect()
+	local bus    = Bus.new({ m_wild = '#', s_wild = '+' })
+	local server = bus:connect()
+	local client = bus:connect()
 
 	local ok1 = pcall(function ()
-		conn:bind({ 'svc', '+' }, { queue_len = 1 })
+		server:bind({ 'svc', '+' }, { queue_len = 1 })
 	end)
 	assert(not ok1, 'expected bind with wildcard to error')
 
 	local ok2 = pcall(function ()
-		conn:publish_one({ 'svc', '+' }, 'x')
+		fibers.perform(client:call_op({ 'svc', '+' }, 'x', { timeout = TMO }))
 	end)
-	assert(not ok2, 'expected publish_one with wildcard topic to error')
+	assert(not ok2, 'expected call with wildcard topic to error')
 
-	local ep = conn:bind({ 'svc', Bus.literal('+') }, { queue_len = 1 })
+	local ep = server:bind({ 'svc', Bus.literal('+') }, { queue_len = 1 })
 	assert(ep, 'expected bind with literal "+" to succeed')
 
-	local ok3, reason3 = conn:publish_one({ 'svc', Bus.literal('+') }, 'ok')
-	assert(ok3 == true and reason3 == nil)
+	fibers.spawn(function ()
+		local req, err = ep:recv()
+		assert(req, tostring(err))
+		assert(req:reply('ok'))
+	end)
 
-	local msg, err = ep:recv()
-	assert(err == nil and msg and msg.payload == 'ok')
+	local reply, err = client:call({ 'svc', Bus.literal('+') }, 'go', { timeout = LONG_TMO })
+	assert(err == nil, tostring(err))
+	assert_eq(reply, 'ok')
 
 	print('Lane B concrete-topic enforcement + literal wrapper test passed!')
 end
 
--- Explicit modality check: publish() does not reach endpoints; publish_one() does.
+-- Explicit modality check: publish() does not reach endpoints; call() does.
 local function test_laneB_endpoint_not_reached_by_publish()
-	local bus  = Bus.new({ m_wild = '#', s_wild = '+' })
-	local conn = bus:connect()
+	local bus    = Bus.new({ m_wild = '#', s_wild = '+' })
+	local server = bus:connect()
+	local client = bus:connect()
 
-	local ep = conn:bind({ 'endpoint', 'only' }, { queue_len = 1 })
+	local ep = server:bind({ 'endpoint', 'only' }, { queue_len = 1 })
 
-	conn:publish({ 'endpoint', 'only' }, 'x')
+	client:publish({ 'endpoint', 'only' }, 'x')
 
 	local which, msg, err = select_named({
 		msg      = ep:recv_op(),
@@ -940,33 +945,37 @@ local function test_laneB_endpoint_not_reached_by_publish()
 	assert_eq(which, 'deadline')
 	assert_timeout(msg, err)
 
-	local ok, reason = conn:publish_one({ 'endpoint', 'only' }, 'y')
-	assert_eq(ok, true)
-	assert(reason == nil)
+	fibers.spawn(function ()
+		local req, rerr = ep:recv()
+		assert(req, tostring(rerr))
+		assert(req:reply('y'))
+	end)
 
-	local m2, e2 = fibers.perform(ep:recv_op())
-	assert(e2 == nil and m2 and m2.payload == 'y')
+	local reply, cerr = client:call({ 'endpoint', 'only' }, 'call', { timeout = LONG_TMO })
+	assert(cerr == nil, tostring(cerr))
+	assert_eq(reply, 'y')
 
 	print('Lane B endpoint not reached by publish test passed!')
 end
 
 local function test_laneB_call_success()
-	local bus    = Bus.new({ m_wild = '#', s_wild = '+' })
-	local server = bus:connect()
-	local client = bus:connect()
+	local bus       = Bus.new({ m_wild = '#', s_wild = '+' })
+	local server    = bus:connect({ principal = admin_principal('server') })
+	local caller_pr = admin_principal('client')
+	local client    = bus:connect({ principal = caller_pr })
 
 	local ep = server:bind({ 'rpc', 'echo' }, { queue_len = 1 })
 
 	fibers.spawn(function ()
-		while true do
-			local msg, err = ep:recv()
-			if not msg then return end
-			if msg.reply_to then
-				local ok, why = reply_best_effort(server, msg.reply_to, 'reply:' .. tostring(msg.payload),
-					{ id = msg.id })
-				assert(ok, tostring(why))
-			end
-		end
+		local req, err = ep:recv()
+		assert(req, tostring(err))
+		assert_eq(req.payload, 'hi')
+		assert_local_origin(req.origin, caller_pr)
+		assert_origin_immutable(req.origin)
+		assert(not req:done(), 'request should not be done before reply')
+		assert(req:reply('reply:' .. tostring(req.payload)))
+		assert(req:done(), 'request should be done after reply')
+		assert(req:reply('again') == false, 'second reply should fail')
 	end)
 
 	local reply, err = client:call({ 'rpc', 'echo' }, 'hi', { timeout = LONG_TMO })
@@ -977,135 +986,67 @@ local function test_laneB_call_success()
 	print('Lane B call (success) test passed!')
 end
 
-local function test_laneB_call_timeout_no_route()
+local function test_laneB_call_no_route()
 	local bus  = Bus.new({ m_wild = '#', s_wild = '+' })
 	local conn = bus:connect()
 
 	local reply, err = conn:call({ 'rpc', 'nobody' }, 'hi', { timeout = TMO })
 	assert(reply == nil)
+	assert_eq(err, 'no_route')
+
+	print('Lane B call (no_route) test passed!')
+end
+
+local function test_laneB_call_timeout_no_reply()
+	local bus       = Bus.new({ m_wild = '#', s_wild = '+' })
+	local server    = bus:connect()
+	local caller_pr = admin_principal('timeout-client')
+	local client    = bus:connect({ principal = caller_pr })
+
+	local ep      = server:bind({ 'rpc', 'timeout' }, { queue_len = 1 })
+	local late_ok = Channel.new(1)
+
+	fibers.spawn(function ()
+		local req, err = ep:recv()
+		assert(req, tostring(err))
+		assert_local_origin(req.origin, caller_pr)
+		Sleep.sleep(LONG_TMO)
+		late_ok:put(req:reply('late'))
+	end)
+
+	local reply, err = client:call({ 'rpc', 'timeout' }, 'slow', { timeout = TMO })
+	assert(reply == nil)
 	assert_eq(err, 'timeout')
 
-	print('Lane B call (timeout no_route) test passed!')
-end
-
---------------------------------------------------------------------------------
--- Request_sub (multi-reply) with “read until deadline” policy
---------------------------------------------------------------------------------
-
-local function test_request_sub()
-	local bus = Bus.new({ m_wild = '#', s_wild = '+' })
-
-	fibers.spawn(function ()
-		local conn     = bus:connect()
-		local helper   = conn:subscribe({ 'helpme' })
-		local rec, err = helper:recv()
-		assert(rec, tostring(err))
-		local ok, why = reply_best_effort(conn, rec.reply_to, 'Sure ' .. tostring(rec.payload), { id = rec.id })
-		assert(ok, tostring(why))
-	end)
-
-	fibers.spawn(function ()
-		local conn     = bus:connect()
-		local helper   = conn:subscribe({ 'helpme' })
-		local rec, err = helper:recv()
-		assert(rec, tostring(err))
-		Sleep.sleep(0.1)
-		local ok, why = reply_best_effort(conn, rec.reply_to, 'No problem ' .. tostring(rec.payload), { id = rec.id })
-		assert(ok, tostring(why))
-	end)
-
-	Sleep.sleep(0.05)
-
-	local conn3 = bus:connect()
-	local sub   = conn3:request_sub({ 'helpme' }, 'John')
-
-	do
-		local which, msg, err = select_named({
-			reply    = sub:recv_op(),
-			deadline = timeout_op(LONG_TMO),
-		})
-		assert_eq(which, 'reply')
-		assert(err == nil and msg and msg.payload == 'Sure John')
-	end
-
-	do
-		local which, msg, err = select_named({
-			reply    = sub:recv_op(),
-			deadline = timeout_op(LONG_TMO),
-		})
-		assert_eq(which, 'reply')
-		assert(err == nil and msg and msg.payload == 'No problem John')
-	end
-
-	do
-		local which, msg, err = select_named({
-			reply    = sub:recv_op(),
-			deadline = timeout_op(TMO),
-		})
-		assert_eq(which, 'deadline')
-		assert_timeout(msg, err)
-	end
-
-	sub:unsubscribe()
-
-	print('Request_sub (multi-reply) test passed!')
-end
-
---------------------------------------------------------------------------------
--- Request_once as a plain Op (caller composes policy)
---------------------------------------------------------------------------------
-
-local function test_request_once_composed()
-	local bus = Bus.new({ m_wild = '#', s_wild = '+' })
-
-	fibers.spawn(function ()
-		local conn     = bus:connect()
-		local helper   = conn:subscribe({ 'helpme' })
-		local rec, err = helper:recv()
-		assert(rec, tostring(err))
-		local ok, why = reply_best_effort(conn, rec.reply_to, 'Sure ' .. tostring(rec.payload), { id = rec.id })
-		assert(ok, tostring(why))
-	end)
-
-	fibers.spawn(function ()
-		local conn     = bus:connect()
-		local helper   = conn:subscribe({ 'helpme' })
-		local rec, err = helper:recv()
-		assert(rec, tostring(err))
-		Sleep.sleep(0.1)
-		local ok, why = reply_best_effort(conn, rec.reply_to, 'No problem ' .. tostring(rec.payload), { id = rec.id })
-		assert(ok, tostring(why))
-	end)
-
-	Sleep.sleep(0.05)
-
-	local conn3 = bus:connect()
-
-	local which, reply, err = select_named({
-		reply    = conn3:request_once_op({ 'helpme' }, 'John'),
+	local which, ok, cherr = select_named({
+		late     = late_ok:get_op():wrap(function (v) return v, nil end),
 		deadline = timeout_op(LONG_TMO),
 	})
+	assert_eq(which, 'late')
+	assert(cherr == nil)
+	assert_eq(ok, false)
 
-	assert_eq(which, 'reply')
-	assert(err == nil, tostring(err))
-	assert(reply and reply.payload == 'Sure John')
-
-	print('Request_once (reply wins) test passed!')
+	print('Lane B call (timeout no reply) test passed!')
 end
 
-local function test_request_once_deadline_no_responder()
-	local bus  = Bus.new({ m_wild = '#', s_wild = '+' })
-	local conn = bus:connect()
+local function test_laneB_call_fail_propagates_error()
+	local bus    = Bus.new({ m_wild = '#', s_wild = '+' })
+	local server = bus:connect()
+	local client = bus:connect()
 
-	local which, reply, err = select_named({
-		reply    = conn:request_once_op({ 'noonehome' }, 'John'),
-		deadline = timeout_op(TMO),
-	})
+	local ep = server:bind({ 'rpc', 'fail' }, { queue_len = 1 })
 
-	assert_eq(which, 'deadline')
-	assert_timeout(reply, err)
+	fibers.spawn(function ()
+		local req, err = ep:recv()
+		assert(req, tostring(err))
+		assert(req:fail('boom'))
+	end)
 
-	print('Request_once (deadline wins) test passed!')
+	local reply, err = client:call({ 'rpc', 'fail' }, 'x', { timeout = LONG_TMO })
+	assert(reply == nil)
+	assert_eq(err, 'boom')
+
+	print('Lane B call (fail propagates error) test passed!')
 end
 
 --------------------------------------------------------------------------------
@@ -1201,6 +1142,7 @@ local function test_authz_admin_allows_and_records_actions()
 	do
 		local msg, err = fibers.perform(sub:recv_op())
 		assert(err == nil and msg and msg.payload == 'hello')
+		assert_local_origin(msg.origin, admin1)
 	end
 
 	-- retain + unretain
@@ -1228,48 +1170,17 @@ local function test_authz_admin_allows_and_records_actions()
 		local ev, err = fibers.perform(rw:recv_op())
 		assert(err == nil and ev and ev.op == 'retain')
 		assert_eq(ev.payload, 'W')
+		assert_local_origin(ev.origin, admin1)
 	end
 	rw:unwatch()
 
-	-- bind + publish_one
-	local ep = conn1:bind({ 'authz', 'ep' }, { queue_len = 1 })
-	do
-		local ok, reason = conn1:publish_one({ 'authz', 'ep' }, 'E')
-		assert_eq(ok, true)
-		assert(reason == nil)
-	end
-	do
-		local msg, err = fibers.perform(ep:recv_op())
-		assert(err == nil and msg and msg.payload == 'E')
-	end
-
-	-- request_sub
-	fibers.spawn(function()
-		local helper_sub = conn2:subscribe({ 'authz', 'request' })
-		local msg, err = helper_sub:recv()
-		assert(msg, tostring(err))
-		local ok, why = reply_best_effort(conn2, msg.reply_to, 'reply:' .. tostring(msg.payload), { id = msg.id })
-		assert(ok, tostring(why))
-	end)
-	Sleep.sleep(TMO)
-	local req_sub = conn1:request_sub({ 'authz', 'request' }, 'Q')
-	do
-		local which, msg, err = select_named({
-			reply    = req_sub:recv_op(),
-			deadline = timeout_op(LONG_TMO),
-		})
-		assert_eq(which, 'reply')
-		assert(err == nil and msg and msg.payload == 'reply:Q')
-	end
-	req_sub:unsubscribe()
-
-	-- call
+	-- bind + call
 	local rpc_ep = conn2:bind({ 'authz', 'rpc' }, { queue_len = 1 })
 	fibers.spawn(function()
-		local msg, err = rpc_ep:recv()
-		assert(msg, tostring(err))
-		local ok, why = reply_best_effort(conn2, msg.reply_to, 'rpc:' .. tostring(msg.payload), { id = msg.id })
-		assert(ok, tostring(why))
+		local req, err = rpc_ep:recv()
+		assert(req, tostring(err))
+		assert_local_origin(req.origin, admin1)
+		assert(req:reply('rpc:' .. tostring(req.payload)))
 	end)
 	do
 		local reply, err = conn1:call({ 'authz', 'rpc' }, 'C', { timeout = LONG_TMO })
@@ -1277,7 +1188,6 @@ local function test_authz_admin_allows_and_records_actions()
 		assert_eq(reply, 'rpc:C')
 	end
 	rpc_ep:unbind()
-	ep:unbind()
 
 	local actions = {}
 	for i = 1, #seen do
@@ -1291,8 +1201,6 @@ local function test_authz_admin_allows_and_records_actions()
 	assert(actions.unretain,       'expected unretain action to be authorised')
 	assert(actions.watch_retained, 'expected watch_retained action to be authorised')
 	assert(actions.bind,           'expected bind action to be authorised')
-	assert(actions.publish_one,    'expected publish_one action to be authorised')
-	assert(actions.request,        'expected request action to be authorised')
 	assert(actions.call,           'expected call action to be authorised')
 
 	print('Authz admin allow/record test passed!')
@@ -1331,15 +1239,13 @@ fibers.run(function ()
 
 	test_laneA_fanout_independent_backpressure()
 
-	test_laneB_publish_one_modalities()
+	test_laneB_call_full_and_closed_modalities()
 	test_laneB_concrete_topic_enforcement_and_literal_ok()
 	test_laneB_endpoint_not_reached_by_publish()
 	test_laneB_call_success()
-	test_laneB_call_timeout_no_route()
-
-	test_request_sub()
-	test_request_once_composed()
-	test_request_once_deadline_no_responder()
+	test_laneB_call_no_route()
+	test_laneB_call_timeout_no_reply()
+	test_laneB_call_fail_propagates_error()
 
 	test_scope_cancellation_terminates_waits()
 	test_authz_denies_without_admin_role()

--- a/tests/test.lua
+++ b/tests/test.lua
@@ -52,6 +52,16 @@ local function assert_origin_immutable(origin)
 	assert(not ok, 'expected origin to be immutable')
 end
 
+local function assert_bus_replay_done(ev)
+	assert(ev, 'expected retained event')
+	assert_eq(ev.op, 'replay_done')
+	assert(ev.topic == nil, 'expected nil topic for replay_done')
+	assert(ev.payload == nil, 'expected nil payload for replay_done')
+	assert(type(ev.origin) == 'table', 'expected origin table on replay_done')
+	assert_eq(ev.origin.kind, 'bus', 'expected bus origin kind')
+	assert_origin_immutable(ev.origin)
+end
+
 -- A standard “deadline arm”: returns (nil, 'timeout').
 local function timeout_op(dt)
 	return Sleep.sleep_op(dt):wrap(function ()
@@ -379,6 +389,12 @@ local function test_retained_watch_replay_and_live_changes()
 		assert_origin_immutable(ev.origin)
 	end
 
+	do
+		local ev, err = fibers.perform(rw:recv_op())
+		assert(err == nil and ev, tostring(err))
+		assert_bus_replay_done(ev)
+	end
+
 	conn:retain({ 'watch', 'b' }, 'B1')
 
 	do
@@ -452,6 +468,15 @@ local function test_retained_watch_no_replay()
 		assert_eq(ev.payload, 'NEW')
 	end
 
+	do
+		local which, ev, err = select_named({
+			ev       = rw:recv_op(),
+			deadline = timeout_op(TMO),
+		})
+		assert_eq(which, 'deadline')
+		assert_timeout(ev, err)
+	end
+
 	rw:unwatch()
 
 	print('Retained watch (no replay) test passed!')
@@ -490,6 +515,9 @@ local function test_retained_watch_wildcards_and_literals()
 			got[ev.payload] = true
 		end
 		assert(got.PLUS and got.ABC, 'wild retained watch should replay PLUS and ABC')
+		local ev, err = fibers.perform(rw_wild:recv_op())
+		assert(err == nil and ev, tostring(err))
+		assert_bus_replay_done(ev)
 	end
 
 	do
@@ -498,15 +526,9 @@ local function test_retained_watch_wildcards_and_literals()
 		assert_eq(ev.op, 'retain')
 		assert_eq(ev.payload, 'PLUS')
 		assert_eq(topic_str(ev.topic), 'metrics/+')
-	end
-
-	do
-		local which, ev, err = select_named({
-			ev       = rw_lit_plus:recv_op(),
-			deadline = timeout_op(TMO),
-		})
-		assert_eq(which, 'deadline')
-		assert_timeout(ev, err)
+		local ev2, err2 = fibers.perform(rw_lit_plus:recv_op())
+		assert(err2 == nil and ev2, tostring(err2))
+		assert_bus_replay_done(ev2)
 	end
 
 	do
@@ -515,6 +537,9 @@ local function test_retained_watch_wildcards_and_literals()
 		assert_eq(ev.op, 'retain')
 		assert_eq(ev.payload, 'HASHMID')
 		assert_eq(topic_str(ev.topic), 'lit/#/x')
+		local ev2, err2 = fibers.perform(rw_lit_hash_mid:recv_op())
+		assert(err2 == nil and ev2, tostring(err2))
+		assert_bus_replay_done(ev2)
 	end
 
 	rw_wild:unwatch()
@@ -600,6 +625,57 @@ local function test_retained_watch_bounded_queue()
 	rw:unwatch()
 
 	print('Retained watch (bounded queue) test passed!')
+end
+
+
+local function test_retained_watch_replay_done_empty()
+	local bus  = Bus.new({ m_wild = '#', s_wild = '+' })
+	local conn = bus:connect()
+
+	local rw = conn:watch_retained({ 'empty', '#' }, {
+		queue_len = 1,
+		full      = 'reject_newest',
+		replay    = true,
+	})
+
+	local ev, err = fibers.perform(rw:recv_op())
+	assert(err == nil and ev, tostring(err))
+	assert_bus_replay_done(ev)
+
+	do
+		local which, ev2, err2 = select_named({
+			ev       = rw:recv_op(),
+			deadline = timeout_op(TMO),
+		})
+		assert_eq(which, 'deadline')
+		assert_timeout(ev2, err2)
+	end
+
+	rw:unwatch()
+	print('Retained watch replay_done (empty replay) test passed!')
+end
+
+local function test_retained_watch_replay_overflow_closes_watch()
+	local bus  = Bus.new({ m_wild = '#', s_wild = '+' })
+	local conn = bus:connect()
+
+	conn:retain({ 'overflow', 'a' }, 'A')
+	conn:retain({ 'overflow', 'b' }, 'B')
+
+	local rw = conn:watch_retained({ 'overflow', '#' }, {
+		queue_len = 1,
+		full      = 'reject_newest',
+		replay    = true,
+	})
+
+	local ev, err = fibers.perform(rw:recv_op())
+	assert(err == nil and ev and ev.op == 'retain', tostring(err))
+
+	local ev2, err2 = fibers.perform(rw:recv_op())
+	assert(ev2 == nil, 'expected watch to close after replay overflow')
+	assert_eq(err2, 'replay_overflow')
+
+	print('Retained watch replay overflow test passed!')
 end
 
 --------------------------------------------------------------------------------
@@ -1165,13 +1241,23 @@ local function test_authz_admin_allows_and_records_actions()
 
 	-- watch_retained
 	local rw = conn1:watch_retained({ 'authz', 'watch' }, { replay = true })
+
+	-- replay=true always emits a replay_done marker, even when the initial set is empty.
+	do
+		local ev, err = fibers.perform(rw:recv_op())
+		assert(err == nil and ev, tostring(err))
+		assert_bus_replay_done(ev)
+	end
+
 	conn1:retain({ 'authz', 'watch' }, 'W')
+
 	do
 		local ev, err = fibers.perform(rw:recv_op())
 		assert(err == nil and ev and ev.op == 'retain')
 		assert_eq(ev.payload, 'W')
 		assert_local_origin(ev.origin, admin1)
 	end
+
 	rw:unwatch()
 
 	-- bind + call
@@ -1227,6 +1313,8 @@ fibers.run(function ()
 	test_retained_watch_wildcards_and_literals()
 	test_retained_watch_unwatch_and_disconnect()
 	test_retained_watch_bounded_queue()
+	test_retained_watch_replay_done_empty()
+	test_retained_watch_replay_overflow_closes_watch()
 
 	test_q_overflow_drop_oldest_default()
 	test_q_overflow_reject_newest_override()

--- a/tests/test.lua
+++ b/tests/test.lua
@@ -984,6 +984,188 @@ local function test_call_request_origin_factory_and_extra()
 end
 
 --------------------------------------------------------------------------------
+-- Derive tests
+--------------------------------------------------------------------------------
+
+local function test_derive_inherits_principal_but_not_origin_factory()
+	local bus       = Bus.new({ m_wild = '#', s_wild = '+' })
+	local principal = admin_principal('derive-base')
+	local seq       = 0
+
+	local base = bus:connect({
+		principal = principal,
+		origin_factory = function ()
+			seq = seq + 1
+			return {
+				kind       = 'fabric_import',
+				link_id    = 'link-base',
+				peer_node  = 'peer-base',
+				peer_sid   = 'sid-base',
+				generation = seq,
+			}
+		end,
+	})
+
+	local sink = bus:connect()
+	local sub  = sink:subscribe({ 'derive', 'inherit' }, { queue_len = 4 })
+	local child = base:derive()
+
+	assert(child:principal() == principal, 'expected derived principal to inherit')
+
+	child:publish({ 'derive', 'inherit' }, 'ok')
+
+	local msg, err = fibers.perform(sub:recv_op())
+	assert(err == nil and msg, tostring(err))
+	assert_eq(msg.payload, 'ok')
+	assert_local_origin(msg.origin, principal)
+	assert(msg.origin.link_id == nil, 'expected origin_factory not to be inherited')
+	assert(msg.origin.peer_node == nil, 'expected origin_factory not to be inherited')
+	assert(msg.origin.peer_sid == nil, 'expected origin_factory not to be inherited')
+	assert(msg.origin.generation == nil, 'expected origin_factory not to be inherited')
+
+	print('Derive inherits principal but not origin_factory test passed!')
+end
+
+local function test_derive_allows_override_principal_and_origin_factory()
+	local bus   = Bus.new({ m_wild = '#', s_wild = '+' })
+	local base  = bus:connect({ principal = admin_principal('parent') })
+	local child_pr = admin_principal('child')
+	local sink  = bus:connect()
+	local sub   = sink:subscribe({ 'derive', 'override' }, { queue_len = 4 })
+
+	local child = base:derive({
+		principal = child_pr,
+		origin_factory = {
+			kind       = 'fabric_import',
+			link_id    = 'link-child',
+			peer_node  = 'peer-child',
+			peer_sid   = 'sid-child',
+			generation = 7,
+		},
+	})
+
+	child:publish({ 'derive', 'override' }, 'payload', {
+		extra = { marker = 'x' },
+	})
+
+	local msg, err = fibers.perform(sub:recv_op())
+	assert(err == nil and msg, tostring(err))
+	assert_eq(msg.payload, 'payload')
+	assert_origin_fields(msg.origin, {
+		kind       = 'fabric_import',
+		link_id    = 'link-child',
+		peer_node  = 'peer-child',
+		peer_sid   = 'sid-child',
+		generation = 7,
+		principal  = child_pr,
+	})
+	assert_eq(msg.origin.extra.marker, 'x')
+
+	print('Derive override principal and origin_factory test passed!')
+end
+
+local function test_derive_disconnected_errors()
+	local bus  = Bus.new({ m_wild = '#', s_wild = '+' })
+	local conn = bus:connect()
+	conn:disconnect()
+
+	local ok = pcall(function ()
+		conn:derive()
+	end)
+	assert(not ok, 'expected derive on disconnected connection to error')
+
+	print('Derive on disconnected connection test passed!')
+end
+
+local function test_derive_connection_scope_cleanup()
+	local bus = Bus.new({ m_wild = '#', s_wild = '+' })
+	local outer = bus:connect()
+	local sub = outer:subscribe({ 'derive', 'scope' }, { queue_len = 4 })
+
+	local st, rep = fibers.run_scope(function (s)
+		local parent = bus:connect({ principal = admin_principal('scoped-parent') })
+		local child  = parent:derive()
+		child:publish({ 'derive', 'scope' }, 'before')
+		Sleep.sleep(TMO)
+	end)
+
+	assert_eq(st, 'ok', 'expected scoped run to complete')
+	assert(rep ~= nil, 'expected scope report')
+
+	do
+		local msg, err = fibers.perform(sub:recv_op())
+		assert(err == nil and msg, tostring(err))
+		assert_eq(msg.payload, 'before')
+	end
+
+	local stats = bus:stats()
+	assert_eq(stats.connections, 1, 'expected only outer connection to remain after scoped cleanup')
+
+	print('Derive connection scope cleanup test passed!')
+end
+
+--------------------------------------------------------------------------------
+-- Request lifecycle tests
+--------------------------------------------------------------------------------
+
+local function test_request_abandon_after_timeout_rejects_late_reply()
+	local bus    = Bus.new({ m_wild = '#', s_wild = '+' })
+	local server = bus:connect()
+	local client = bus:connect()
+
+	local ep = server:bind({ 'rpc', 'abandon' }, { queue_len = 1 })
+	local late = Channel.new(1)
+
+	fibers.spawn(function ()
+		local req, err = ep:recv()
+		assert(req, tostring(err))
+		Sleep.sleep(LONG_TMO)
+		late:put(req:reply('too-late'))
+	end)
+
+	local reply, err = client:call({ 'rpc', 'abandon' }, 'x', { timeout = TMO })
+	assert(reply == nil)
+	assert_eq(err, 'timeout')
+
+	local which, ok, cherr = select_named({
+		late     = late:get_op():wrap(function (v) return v, nil end),
+		deadline = timeout_op(LONG_TMO),
+	})
+	assert_eq(which, 'late')
+	assert(cherr == nil)
+	assert_eq(ok, false)
+
+	print('Request abandon after timeout rejects late reply test passed!')
+end
+
+local function test_request_done_state_for_fail_and_abandon()
+	local req = Bus.Request and Bus.Request or error('Bus.Request missing')
+	local origin = setmetatable({}, { __index = { kind = 'local' }, __newindex = function () error('immutable') end })
+	local r = req.__index and nil
+	-- Use the real command plane instead of constructing Request internals directly.
+	local bus    = Bus.new({ m_wild = '#', s_wild = '+' })
+	local server = bus:connect()
+	local client = bus:connect()
+
+	local ep = server:bind({ 'rpc', 'done' }, { queue_len = 1 })
+	fibers.spawn(function ()
+		local request, err = ep:recv()
+		assert(request, tostring(err))
+		assert(not request:done(), 'request should not be done initially')
+		assert(request:fail('failed-now'))
+		assert(request:done(), 'request should be done after fail')
+		assert(request:abandon('later') == false, 'abandon after fail should return false')
+		assert(request:reply('later') == false, 'reply after fail should return false')
+	end)
+
+	local value, err = client:call({ 'rpc', 'done' }, 'x', { timeout = LONG_TMO })
+	assert(value == nil)
+	assert_eq(err, 'failed-now')
+
+	print('Request done state for fail/abandon test passed!')
+end
+
+--------------------------------------------------------------------------------
 -- Unsubscribe Test
 --------------------------------------------------------------------------------
 
@@ -1498,6 +1680,11 @@ local function test_authz_denies_without_admin_role()
 	assert(not ok5, 'expected watch_retained without admin role to be denied')
 	assert(tostring(err5):match('permission denied'), tostring(err5))
 
+	local ok6, err6 = pcall(function()
+		conn_viewer:derive()
+	end)
+	assert(ok6, 'expected derive itself not to be authoriser-gated: ' .. tostring(err6))
+
 	print('Authz deny test passed!')
 end
 
@@ -1626,6 +1813,14 @@ fibers.run(function ()
 	test_retained_replay_preserves_original_origin()
 	test_unretain_event_origin_metadata()
 	test_call_request_origin_factory_and_extra()
+
+	test_derive_inherits_principal_but_not_origin_factory()
+	test_derive_allows_override_principal_and_origin_factory()
+	test_derive_disconnected_errors()
+	test_derive_connection_scope_cleanup()
+
+	test_request_abandon_after_timeout_rejects_late_reply()
+	test_request_done_state_for_fail_and_abandon()
 
 	test_q_overflow_drop_oldest_default()
 	test_q_overflow_reject_newest_override()

--- a/tests/test.lua
+++ b/tests/test.lua
@@ -62,6 +62,19 @@ local function assert_bus_replay_done(ev)
 	assert_origin_immutable(ev.origin)
 end
 
+local function assert_origin_fields(origin, expected)
+	assert(type(origin) == 'table', 'expected origin table')
+	for k, v in pairs(expected) do
+		assert_eq(origin[k], v, 'unexpected origin field ' .. tostring(k))
+	end
+end
+
+local function assert_origin_extra_immutable(origin)
+	assert(type(origin.extra) == 'table', 'expected origin.extra table')
+	local ok = pcall(function () origin.extra.changed = true end)
+	assert(not ok, 'expected origin.extra to be immutable')
+end
+
 -- A standard “deadline arm”: returns (nil, 'timeout').
 local function timeout_op(dt)
 	return Sleep.sleep_op(dt):wrap(function ()
@@ -627,7 +640,6 @@ local function test_retained_watch_bounded_queue()
 	print('Retained watch (bounded queue) test passed!')
 end
 
-
 local function test_retained_watch_replay_done_empty()
 	local bus  = Bus.new({ m_wild = '#', s_wild = '+' })
 	local conn = bus:connect()
@@ -676,6 +688,299 @@ local function test_retained_watch_replay_overflow_closes_watch()
 	assert_eq(err2, 'replay_overflow')
 
 	print('Retained watch replay overflow test passed!')
+end
+
+--------------------------------------------------------------------------------
+-- Additional origin / provenance tests
+--------------------------------------------------------------------------------
+
+local function test_origin_factory_function_and_extra_on_publish()
+	local bus    = Bus.new({ m_wild = '#', s_wild = '+' })
+	local pub_pr = admin_principal('origin-pub')
+	local seq    = 0
+
+	local conn = bus:connect({
+		principal = pub_pr,
+		origin_factory = function ()
+			seq = seq + 1
+			return {
+				link_id    = 'link-pub',
+				peer_node  = 'peer-pub',
+				peer_sid   = 'sid-pub',
+				generation = seq,
+			}
+		end,
+	})
+
+	local sub = conn:subscribe({ 'origin', 'publish' }, { queue_len = 10 })
+
+	conn:publish({ 'origin', 'publish' }, 'one', {
+		extra = {
+			note    = 'n1',
+			kind    = 'spoof-attempt',
+			link_id = 'fake-link',
+		},
+	})
+
+	conn:publish({ 'origin', 'publish' }, 'two')
+
+	do
+		local msg, err = fibers.perform(sub:recv_op())
+		assert(err == nil and msg, tostring(err))
+		assert_eq(msg.payload, 'one')
+
+		assert_local_origin(msg.origin, pub_pr)
+		assert_origin_fields(msg.origin, {
+			link_id    = 'link-pub',
+			peer_node  = 'peer-pub',
+			peer_sid   = 'sid-pub',
+			generation = 1,
+		})
+
+		assert(type(msg.origin.extra) == 'table', 'expected origin.extra')
+		assert_eq(msg.origin.extra.note, 'n1')
+		assert_eq(msg.origin.extra.kind, 'spoof-attempt')
+		assert_eq(msg.origin.extra.link_id, 'fake-link')
+
+		assert_origin_immutable(msg.origin)
+		assert_origin_extra_immutable(msg.origin)
+	end
+
+	do
+		local msg, err = fibers.perform(sub:recv_op())
+		assert(err == nil and msg, tostring(err))
+		assert_eq(msg.payload, 'two')
+
+		assert_local_origin(msg.origin, pub_pr)
+		assert_origin_fields(msg.origin, {
+			link_id    = 'link-pub',
+			peer_node  = 'peer-pub',
+			peer_sid   = 'sid-pub',
+			generation = 2,
+		})
+
+		assert(msg.origin.extra == nil, 'expected no origin.extra on second publish')
+	end
+
+	print('Origin factory function + extra on publish test passed!')
+end
+
+local function test_origin_conn_ids_distinct_between_connections()
+	local bus   = Bus.new({ m_wild = '#', s_wild = '+' })
+	local sink  = bus:connect()
+	local sub   = sink:subscribe({ 'origin', 'connid' }, { queue_len = 10 })
+
+	local p1 = admin_principal('c1')
+	local p2 = admin_principal('c2')
+
+	local c1 = bus:connect({ principal = p1 })
+	local c2 = bus:connect({ principal = p2 })
+
+	c1:publish({ 'origin', 'connid' }, 'm1')
+	c2:publish({ 'origin', 'connid' }, 'm2')
+
+	local m1, e1 = fibers.perform(sub:recv_op())
+	local m2, e2 = fibers.perform(sub:recv_op())
+
+	assert(e1 == nil and m1, tostring(e1))
+	assert(e2 == nil and m2, tostring(e2))
+
+	assert_local_origin(m1.origin, p1)
+	assert_local_origin(m2.origin, p2)
+
+	assert(m1.origin.conn_id ~= nil, 'expected conn_id on first origin')
+	assert(m2.origin.conn_id ~= nil, 'expected conn_id on second origin')
+	assert(m1.origin.conn_id ~= m2.origin.conn_id, 'expected distinct conn_id values')
+
+	print('Origin conn_id distinctness test passed!')
+end
+
+local function test_retained_replay_preserves_original_origin()
+	local bus = Bus.new({ m_wild = '#', s_wild = '+' })
+
+	local source = bus:connect({
+		principal = admin_principal('ret-source'),
+		origin_factory = {
+			kind       = 'fabric_import',
+			link_id    = 'link-ret',
+			peer_node  = 'peer-ret',
+			peer_sid   = 'sid-ret',
+			generation = 17,
+		},
+	})
+
+	source:retain({ 'origin', 'retained' }, 'R1', {
+		extra = { trace = 'retain-trace' },
+	})
+
+	local sub = bus:connect():subscribe({ 'origin', 'retained' })
+	do
+		local msg, err = fibers.perform(sub:recv_op())
+		assert(err == nil and msg, tostring(err))
+		assert_eq(msg.payload, 'R1')
+
+		assert_origin_fields(msg.origin, {
+			kind       = 'fabric_import',
+			link_id    = 'link-ret',
+			peer_node  = 'peer-ret',
+			peer_sid   = 'sid-ret',
+			generation = 17,
+		})
+		assert_eq(msg.origin.extra.trace, 'retain-trace')
+		assert_origin_immutable(msg.origin)
+		assert_origin_extra_immutable(msg.origin)
+	end
+
+	local rw = bus:connect():watch_retained({ 'origin', 'retained' }, {
+		queue_len = 4,
+		full      = 'reject_newest',
+		replay    = true,
+	})
+
+	do
+		local ev, err = fibers.perform(rw:recv_op())
+		assert(err == nil and ev, tostring(err))
+		assert_eq(ev.op, 'retain')
+		assert_eq(ev.payload, 'R1')
+
+		assert_origin_fields(ev.origin, {
+			kind       = 'fabric_import',
+			link_id    = 'link-ret',
+			peer_node  = 'peer-ret',
+			peer_sid   = 'sid-ret',
+			generation = 17,
+		})
+		assert_eq(ev.origin.extra.trace, 'retain-trace')
+	end
+
+	do
+		local ev, err = fibers.perform(rw:recv_op())
+		assert(err == nil and ev, tostring(err))
+		assert_bus_replay_done(ev)
+	end
+
+	rw:unwatch()
+
+	print('Retained replay preserves original origin test passed!')
+end
+
+local function test_unretain_event_origin_metadata()
+	local bus = Bus.new({ m_wild = '#', s_wild = '+' })
+	local pr  = admin_principal('origin-unretain')
+
+	local conn = bus:connect({
+		principal = pr,
+		origin_factory = {
+			link_id    = 'link-unretain',
+			peer_node  = 'peer-unretain',
+			peer_sid   = 'sid-unretain',
+			generation = 33,
+		},
+	})
+
+	local rw = conn:watch_retained({ 'origin', 'gone' }, {
+		queue_len = 4,
+		full      = 'reject_newest',
+		replay    = false,
+	})
+
+	conn:retain({ 'origin', 'gone' }, 'value')
+	do
+		local ev, err = fibers.perform(rw:recv_op())
+		assert(err == nil and ev and ev.op == 'retain', tostring(err))
+	end
+
+	conn:unretain({ 'origin', 'gone' }, {
+		extra = {
+			reason     = 'manual-clear',
+			generation = 'fake-generation',
+		},
+	})
+
+	do
+		local ev, err = fibers.perform(rw:recv_op())
+		assert(err == nil and ev, tostring(err))
+		assert_eq(ev.op, 'unretain')
+		assert_eq(topic_str(ev.topic), 'origin/gone')
+		assert(ev.payload == nil, 'expected nil payload on unretain')
+
+		assert_local_origin(ev.origin, pr)
+		assert_origin_fields(ev.origin, {
+			link_id    = 'link-unretain',
+			peer_node  = 'peer-unretain',
+			peer_sid   = 'sid-unretain',
+			generation = 33,
+		})
+		assert_eq(ev.origin.extra.reason, 'manual-clear')
+		assert_eq(ev.origin.extra.generation, 'fake-generation')
+
+		assert_origin_immutable(ev.origin)
+		assert_origin_extra_immutable(ev.origin)
+	end
+
+	rw:unwatch()
+
+	print('Unretain event origin metadata test passed!')
+end
+
+local function test_call_request_origin_factory_and_extra()
+	local bus       = Bus.new({ m_wild = '#', s_wild = '+' })
+	local server    = bus:connect({ principal = admin_principal('rpc-server') })
+	local caller_pr = admin_principal('rpc-caller')
+
+	local client = bus:connect({
+		principal = caller_pr,
+		origin_factory = function ()
+			return {
+				link_id    = 'link-call',
+				peer_node  = 'peer-call',
+				peer_sid   = 'sid-call',
+				generation = 44,
+			}
+		end,
+	})
+
+	local ep = server:bind({ 'origin', 'rpc' }, { queue_len = 1 })
+
+	fibers.spawn(function ()
+		local req, err = ep:recv()
+		assert(req, tostring(err))
+
+		assert_eq(topic_str(req.topic), 'origin/rpc')
+		assert_eq(req.payload, 'ping')
+
+		assert_local_origin(req.origin, caller_pr)
+		assert_origin_fields(req.origin, {
+			link_id    = 'link-call',
+			peer_node  = 'peer-call',
+			peer_sid   = 'sid-call',
+			generation = 44,
+		})
+
+		assert(type(req.origin.extra) == 'table', 'expected origin.extra on request')
+		assert_eq(req.origin.extra.note, 'rpc-extra')
+		assert_eq(req.origin.extra.link_id, 'fake-link')
+
+		assert_origin_immutable(req.origin)
+		assert_origin_extra_immutable(req.origin)
+
+		assert(req:reply('pong'))
+	end)
+
+	local reply, err = client:call({ 'origin', 'rpc' }, 'ping', {
+		timeout = LONG_TMO,
+		extra   = {
+			note    = 'rpc-extra',
+			link_id = 'fake-link',
+		},
+	})
+
+	assert(err == nil, tostring(err))
+	assert_eq(reply, 'pong')
+
+	ep:unbind()
+
+	print('Call request origin factory + extra test passed!')
 end
 
 --------------------------------------------------------------------------------
@@ -1315,6 +1620,12 @@ fibers.run(function ()
 	test_retained_watch_bounded_queue()
 	test_retained_watch_replay_done_empty()
 	test_retained_watch_replay_overflow_closes_watch()
+
+	test_origin_factory_function_and_extra_on_publish()
+	test_origin_conn_ids_distinct_between_connections()
+	test_retained_replay_preserves_original_origin()
+	test_unretain_event_origin_metadata()
+	test_call_request_origin_factory_and_extra()
 
 	test_q_overflow_drop_oldest_default()
 	test_q_overflow_reject_newest_override()

--- a/tests/test.lua
+++ b/tests/test.lua
@@ -1545,6 +1545,108 @@ local function test_request_done_state_for_fail_and_abandon()
 	print('Request done state for fail/abandon test passed!')
 end
 
+
+local function test_request_status_and_done_op_for_all_terminal_states()
+	local bus    = Bus.new({ m_wild = '#', s_wild = '+' })
+	local server = bus:connect()
+	local client = bus:connect()
+
+	local ep = server:bind({ 'rpc', 'status' }, { queue_len = 3 })
+
+	fibers.spawn(function ()
+		local req = assert(ep:recv())
+		assert_eq(select(1, req:status()), 'pending')
+		assert(req:reply('ok'))
+	end)
+	local v, err = client:call({ 'rpc', 'status' }, 'reply', { timeout = LONG_TMO })
+	assert_eq(v, 'ok')
+	assert(err == nil, tostring(err))
+
+	fibers.spawn(function ()
+		local req = assert(ep:recv())
+		assert(req:fail('bad'))
+		local status, value, ferr = fibers.perform(req:done_op())
+		assert_eq(status, 'failed')
+		assert(value == nil)
+		assert_eq(ferr, 'bad')
+	end)
+	v, err = client:call({ 'rpc', 'status' }, 'fail', { timeout = LONG_TMO })
+	assert(v == nil)
+	assert_eq(err, 'bad')
+
+	local abandoned = Channel.new(1)
+	fibers.spawn(function ()
+		local req = assert(ep:recv())
+		local status, value, aerr = fibers.perform(req:done_op())
+		abandoned:put({ status = status, value = value, err = aerr })
+	end)
+	v, err = client:call({ 'rpc', 'status' }, 'abandon', { timeout = TMO })
+	assert(v == nil)
+	assert_eq(err, 'timeout')
+	local rec = abandoned:get()
+	assert_eq(rec.status, 'abandoned')
+	assert(rec.value == nil)
+	assert_eq(rec.err, 'timeout')
+
+	print('Request status and done_op terminal-state test passed!')
+end
+
+local function test_call_op_abort_abandons_request_and_wakes_done_op()
+	local bus    = Bus.new({ m_wild = '#', s_wild = '+' })
+	local server = bus:connect()
+	local client = bus:connect()
+	local ep     = server:bind({ 'rpc', 'abort' }, { queue_len = 1 })
+	local seen   = Channel.new(1)
+
+	fibers.spawn(function ()
+		local req = assert(ep:recv())
+		local status, value, err = fibers.perform(req:done_op())
+		seen:put({ status = status, value = value, err = err, late_reply = req:reply('late') })
+	end)
+
+	local which, value, err = select_named({
+		call = client:call_op({ 'rpc', 'abort' }, 'payload', { timeout = false }),
+		stop = timeout_op(TMO),
+	})
+	assert_eq(which, 'stop')
+	assert(value == nil)
+	assert_eq(err, 'timeout')
+
+	local rec = seen:get()
+	assert_eq(rec.status, 'abandoned')
+	assert(rec.value == nil)
+	assert_eq(rec.err, 'aborted')
+	assert_eq(rec.late_reply, false)
+
+	print('call_op abort abandons request and wakes done_op test passed!')
+end
+
+local function test_call_op_timeout_false_has_no_hidden_deadline()
+	local bus    = Bus.new({ m_wild = '#', s_wild = '+' })
+	local server = bus:connect()
+	local client = bus:connect()
+	local ep     = server:bind({ 'rpc', 'no-hidden-timeout' }, { queue_len = 1 })
+	local done   = Channel.new(1)
+
+	fibers.spawn(function ()
+		local req = assert(ep:recv())
+		local status, _value, err = fibers.perform(req:done_op())
+		done:put({ status = status, err = err })
+	end)
+
+	local which = select_named({
+		call = client:call_op({ 'rpc', 'no-hidden-timeout' }, 'payload', { timeout = false }),
+		stop = timeout_op(TMO),
+	})
+	assert_eq(which, 'stop')
+
+	local rec = done:get()
+	assert_eq(rec.status, 'abandoned')
+	assert_eq(rec.err, 'aborted')
+
+	print('call_op timeout=false no-hidden-deadline test passed!')
+end
+
 --------------------------------------------------------------------------------
 -- Unsubscribe Test
 --------------------------------------------------------------------------------
@@ -2221,6 +2323,9 @@ fibers.run(function ()
 
 	test_request_abandon_after_timeout_rejects_late_reply()
 	test_request_done_state_for_fail_and_abandon()
+	test_request_status_and_done_op_for_all_terminal_states()
+	test_call_op_abort_abandons_request_and_wakes_done_op()
+	test_call_op_timeout_false_has_no_hidden_deadline()
 
 	test_q_overflow_drop_oldest_default()
 	test_q_overflow_reject_newest_override()

--- a/tests/test.lua
+++ b/tests/test.lua
@@ -892,15 +892,27 @@ local function test_retained_view_wildcards_and_literal_tokens()
 	local view_lit_hash_mid = conn:retained_view({ 'viewlit', 'lit', Bus.literal('#'), 'x' })
 
 	assert_eq(#view_wild:snapshot(), 2, 'wild view should include PLUS and ABC')
-	assert(view_wild:get({ 'viewlit', 'metrics', '+' }).payload == 'PLUS')
+	assert(view_wild:get({ 'viewlit', 'metrics', Bus.literal('+') }).payload == 'PLUS')
 	assert(view_wild:get({ 'viewlit', 'metrics', 'abc' }).payload == 'ABC')
 
 	assert_eq(#view_lit_plus:snapshot(), 1, 'literal plus view should include only literal plus')
-	assert(view_lit_plus:get({ 'viewlit', 'metrics', '+' }).payload == 'PLUS')
+	assert(view_lit_plus:get({ 'viewlit', 'metrics', Bus.literal('+') }).payload == 'PLUS')
 	assert(view_lit_plus:get({ 'viewlit', 'metrics', 'abc' }) == nil)
 
 	assert_eq(#view_lit_hash_mid:snapshot(), 1, 'literal hash view should include only literal hash mid-token')
-	assert(view_lit_hash_mid:get({ 'viewlit', 'lit', '#', 'x' }).payload == 'HASHMID')
+	assert(view_lit_hash_mid:get({ 'viewlit', 'lit', Bus.literal('#'), 'x' }).payload == 'HASHMID')
+
+	local ok, err = pcall(function()
+		view_wild:get({ 'viewlit', 'metrics', '+' })
+	end)
+	assert(not ok, 'retained_view:get should reject wildcard lookup topics')
+	assert(tostring(err):match('concrete topic'), 'error should explain concrete-topic requirement')
+
+	ok, err = pcall(function()
+		view_lit_hash_mid:get({ 'viewlit', 'lit', '#', 'x' })
+	end)
+	assert(not ok, 'retained_view:get should reject wildcard lookup topics')
+	assert(tostring(err):match('concrete topic'), 'error should explain concrete-topic requirement')
 
 	view_wild:close()
 	view_lit_plus:close()

--- a/tests/test.lua
+++ b/tests/test.lua
@@ -38,6 +38,14 @@ local function topic_str(topic)
 	return table.concat(parts, '/')
 end
 
+local function table_count(t)
+	local n = 0
+	for _ in pairs(t or {}) do
+		n = n + 1
+	end
+	return n
+end
+
 local function assert_local_origin(origin, principal)
 	assert(type(origin) == 'table', 'expected origin table')
 	assert_eq(origin.kind, 'local', 'expected local origin kind')
@@ -85,6 +93,18 @@ end
 -- Named-choice convenience: returns (winner_name, ...arm_results...)
 local function select_named(arms)
 	return fibers.perform(fibers.named_choice(arms))
+end
+
+local function wait_view_changed(view, last_seen, label)
+	local which, version, err = select_named({
+		changed  = view:changed_op(last_seen):wrap(function (v) return v, nil end),
+		deadline = timeout_op(LONG_TMO),
+	})
+
+	assert_eq(which, 'changed', label or 'expected retained view to change')
+	assert(err == nil, tostring(err))
+	assert(type(version) == 'number', 'expected numeric retained view version')
+	return version
 end
 
 --------------------------------------------------------------------------------
@@ -691,6 +711,325 @@ local function test_retained_watch_replay_overflow_closes_watch()
 end
 
 --------------------------------------------------------------------------------
+-- Feed handle shape tests
+--------------------------------------------------------------------------------
+
+local function test_feed_distinct_metatables_and_method_guards()
+	local bus  = Bus.new({ m_wild = '#', s_wild = '+' })
+	local conn = bus:connect()
+
+	local sub = conn:subscribe({ 'feed', 'sub' })
+	local rw  = conn:watch_retained({ 'feed', 'rw' })
+	local ep  = conn:bind({ 'feed', 'ep' }, { queue_len = 1 })
+
+	assert_eq(getmetatable(sub), Bus.Subscription, 'subscription metatable')
+	assert_eq(getmetatable(rw),  Bus.RetainedWatch, 'retained watch metatable')
+	assert_eq(getmetatable(ep),  Bus.Endpoint, 'endpoint metatable')
+
+	assert(Bus.Subscription ~= Bus.RetainedWatch, 'Subscription and RetainedWatch should be distinct')
+	assert(Bus.Subscription ~= Bus.Endpoint, 'Subscription and Endpoint should be distinct')
+	assert(Bus.RetainedWatch ~= Bus.Endpoint, 'RetainedWatch and Endpoint should be distinct')
+
+	assert_eq(sub:kind(), 'subscription')
+	assert_eq(rw:kind(), 'retained_watch')
+	assert_eq(ep:kind(), 'endpoint')
+
+	assert_eq(topic_str(sub:topic()), 'feed/sub')
+	assert_eq(topic_str(rw:topic()), 'feed/rw')
+	assert_eq(topic_str(ep:topic()), 'feed/ep')
+
+	local ok_payloads = pcall(function () rw:payloads() end)
+	assert(not ok_payloads, 'expected retained watch payloads() to error')
+
+	local ok_unwatch_sub = pcall(function () sub:unwatch() end)
+	assert(not ok_unwatch_sub, 'expected subscription:unwatch() to error')
+
+	local ok_unsub_rw = pcall(function () rw:unsubscribe() end)
+	assert(not ok_unsub_rw, 'expected retained_watch:unsubscribe() to error')
+
+	local ok_unsub_ep = pcall(function () ep:unsubscribe() end)
+	assert(not ok_unsub_ep, 'expected endpoint:unsubscribe() to error')
+
+	local ok_unbind_sub = pcall(function () sub:unbind() end)
+	assert(not ok_unbind_sub, 'expected subscription:unbind() to error')
+
+	sub:unsubscribe()
+	rw:unwatch()
+	ep:unbind()
+
+	print('Feed distinct metatables + method guards test passed!')
+end
+
+local function test_feed_closed_op_reason()
+	local bus  = Bus.new({ m_wild = '#', s_wild = '+' })
+	local conn = bus:connect()
+
+	local sub = conn:subscribe({ 'feed', 'closed', 'sub' })
+	local rw  = conn:watch_retained({ 'feed', 'closed', 'rw' })
+	local ep  = conn:bind({ 'feed', 'closed', 'ep' }, { queue_len = 1 })
+
+	sub:unsubscribe()
+	rw:unwatch()
+	ep:unbind()
+
+	do
+		local reason = fibers.perform(sub:closed_op())
+		assert_eq(reason, 'unsubscribed')
+	end
+
+	do
+		local reason = fibers.perform(rw:closed_op())
+		assert_eq(reason, 'unwatched')
+	end
+
+	do
+		local reason = fibers.perform(ep:closed_op())
+		assert_eq(reason, 'unbound')
+	end
+
+	print('Feed closed_op reason test passed!')
+end
+
+--------------------------------------------------------------------------------
+-- Retained materialised view tests
+--------------------------------------------------------------------------------
+
+local function test_retained_view_empty_replay_ready()
+	local bus  = Bus.new({ m_wild = '#', s_wild = '+' })
+	local conn = bus:connect()
+
+	local view = conn:retained_view({ 'view', 'empty', '#' })
+
+	assert_eq(getmetatable(view), Bus.RetainedView)
+	assert_eq(view:version(), 0)
+	assert_eq(conn:stats().retained_views, 1)
+	assert_eq(bus:stats().retained_views, 1)
+	assert(view:get({ 'view', 'empty', 'missing' }) == nil, 'expected empty view')
+
+	do
+		local which, version, err = select_named({
+			changed  = view:changed_op(view:version()):wrap(function (v) return v, nil end),
+			deadline = timeout_op(TMO),
+		})
+		assert_eq(which, 'deadline')
+		assert_timeout(version, err)
+	end
+
+	view:close()
+
+	assert_eq(conn:stats().retained_views, 0)
+	assert_eq(bus:stats().retained_views, 0)
+
+	do
+		local reason = fibers.perform(view:closed_op())
+		assert_eq(reason, 'closed')
+	end
+
+	print('Retained view empty replay ready test passed!')
+end
+
+local function test_retained_view_replay_snapshot_and_live_changes()
+	local bus  = Bus.new({ m_wild = '#', s_wild = '+' })
+	local conn = bus:connect()
+
+	conn:retain({ 'view', 'state', 'a' }, 'A1')
+	conn:retain({ 'view', 'state', 'b' }, 'B1')
+	conn:retain({ 'view', 'other', 'x' }, 'X1')
+
+	local view = conn:retained_view({ 'view', 'state', '#' })
+
+	assert_eq(conn:stats().retained_views, 1)
+	assert_eq(bus:stats().retained_views, 1)
+
+	local ma = view:get({ 'view', 'state', 'a' })
+	local mb = view:get({ 'view', 'state', 'b' })
+	local mx = view:get({ 'view', 'other', 'x' })
+
+	assert(ma and ma.payload == 'A1', 'expected replayed A1')
+	assert(mb and mb.payload == 'B1', 'expected replayed B1')
+	assert(mx == nil, 'expected non-matching retained topic to be absent')
+	assert_eq(table_count(view:snapshot()), 2, 'expected two retained view items')
+	assert(view:version() >= 2, 'expected replay to advance version')
+
+	local last = view:version()
+
+	conn:retain({ 'view', 'state', 'a' }, 'A2')
+	last = wait_view_changed(view, last, 'expected retain update to change view')
+
+	do
+		local msg = view:get({ 'view', 'state', 'a' })
+		assert(msg and msg.payload == 'A2', 'expected updated retained payload')
+		assert_local_origin(msg.origin)
+	end
+
+	conn:retain({ 'view', 'other', 'x' }, 'X2')
+
+	do
+		local which, version, err = select_named({
+			changed  = view:changed_op(last):wrap(function (v) return v, nil end),
+			deadline = timeout_op(TMO),
+		})
+		assert_eq(which, 'deadline')
+		assert_timeout(version, err)
+	end
+
+	conn:unretain({ 'view', 'state', 'b' })
+	last = wait_view_changed(view, last, 'expected unretain to change view')
+
+	assert(view:get({ 'view', 'state', 'b' }) == nil, 'expected b to be removed')
+	assert_eq(table_count(view:items()), 1, 'expected one retained view item after unretain')
+
+	view:close()
+
+	print('Retained view replay snapshot + live changes test passed!')
+end
+
+local function test_retained_view_wildcards_and_literal_tokens()
+	local bus  = Bus.new({ m_wild = '#', s_wild = '+' })
+	local conn = bus:connect()
+
+	conn:retain({ 'viewlit', 'metrics', '+' }, 'PLUS')
+	conn:retain({ 'viewlit', 'metrics', 'abc' }, 'ABC')
+	conn:retain({ 'viewlit', 'lit', '#', 'x' }, 'HASHMID')
+
+	local view_wild = conn:retained_view({ 'viewlit', 'metrics', '+' })
+	local view_lit_plus = conn:retained_view({ 'viewlit', 'metrics', Bus.literal('+') })
+	local view_lit_hash_mid = conn:retained_view({ 'viewlit', 'lit', Bus.literal('#'), 'x' })
+
+	assert_eq(table_count(view_wild:snapshot()), 2, 'wild view should include PLUS and ABC')
+	assert(view_wild:get({ 'viewlit', 'metrics', '+' }).payload == 'PLUS')
+	assert(view_wild:get({ 'viewlit', 'metrics', 'abc' }).payload == 'ABC')
+
+	assert_eq(table_count(view_lit_plus:snapshot()), 1, 'literal plus view should include only literal plus')
+	assert(view_lit_plus:get({ 'viewlit', 'metrics', '+' }).payload == 'PLUS')
+	assert(view_lit_plus:get({ 'viewlit', 'metrics', 'abc' }) == nil)
+
+	assert_eq(table_count(view_lit_hash_mid:snapshot()), 1, 'literal hash view should include only literal hash mid-token')
+	assert(view_lit_hash_mid:get({ 'viewlit', 'lit', '#', 'x' }).payload == 'HASHMID')
+
+	view_wild:close()
+	view_lit_plus:close()
+	view_lit_hash_mid:close()
+
+	print('Retained view wildcards + literal tokens test passed!')
+end
+
+local function test_retained_view_changed_op_integer_validation()
+	local bus  = Bus.new({ m_wild = '#', s_wild = '+' })
+	local conn = bus:connect()
+	local view = conn:retained_view({ 'view', 'validation' })
+
+	local bad_values = {
+		nil,
+		1.5,
+		'0',
+		{},
+	}
+
+	for _, v in ipairs(bad_values) do
+		local ok = pcall(function ()
+			view:changed_op(v)
+		end)
+		assert(not ok, 'expected changed_op to reject non-integer last_seen')
+	end
+
+	local ok = pcall(function ()
+		view:changed_op(0)
+	end)
+	assert(ok, 'expected changed_op to accept integer last_seen')
+
+	view:close()
+
+	print('Retained view changed_op integer validation test passed!')
+end
+
+local function test_retained_view_close_and_disconnect()
+	local bus  = Bus.new({ m_wild = '#', s_wild = '+' })
+	local conn = bus:connect()
+
+	local view = conn:retained_view({ 'view', 'close' })
+	assert_eq(bus:stats().retained_views, 1)
+
+	local last = view:version()
+	view:close()
+
+	do
+		local which, version, err = select_named({
+			changed  = view:changed_op(last):wrap(function (v) return v, nil end),
+			deadline = timeout_op(LONG_TMO),
+		})
+		assert_eq(which, 'changed')
+		assert(err == nil)
+		assert(version > last, 'expected close to advance view version')
+	end
+
+	do
+		local reason = fibers.perform(view:closed_op())
+		assert_eq(reason, 'closed')
+	end
+
+	assert_eq(conn:stats().retained_views, 0)
+	assert_eq(bus:stats().retained_views, 0)
+
+	local conn2 = bus:connect()
+	local view2 = conn2:retained_view({ 'view', 'disconnect' })
+	assert_eq(bus:stats().retained_views, 1)
+
+	conn2:disconnect()
+
+	do
+		local reason = fibers.perform(view2:closed_op())
+		assert_eq(reason, 'disconnected')
+	end
+
+	assert_eq(bus:stats().retained_views, 0)
+
+	print('Retained view close + disconnect test passed!')
+end
+
+local function test_retained_view_scope_cleanup()
+	local bus = Bus.new({ m_wild = '#', s_wild = '+' })
+
+	local st, rep = fibers.run_scope(function ()
+		local conn = bus:connect()
+		local view = conn:retained_view({ 'view', 'scope' })
+		assert_eq(conn:stats().retained_views, 1)
+		assert_eq(bus:stats().retained_views, 1)
+		assert(view ~= nil)
+	end)
+
+	assert_eq(st, 'ok', 'expected scope to finish cleanly')
+	assert(rep ~= nil, 'expected scope report')
+	assert_eq(bus:stats().retained_views, 0, 'expected scoped retained view to be removed')
+
+	print('Retained view scope cleanup test passed!')
+end
+
+local function test_retained_view_no_queue_overflow_or_background_fibre()
+	local bus  = Bus.new({ m_wild = '#', s_wild = '+' })
+	local conn = bus:connect()
+
+	for i = 1, 20 do
+		conn:retain({ 'view', 'many', i }, 'V' .. i)
+	end
+
+	local view = conn:retained_view({ 'view', 'many', '#' }, {
+		queue_len = 0,
+		full      = 'reject_newest',
+	})
+
+	assert_eq(table_count(view:snapshot()), 20, 'retained view should materialise all matching retained state')
+	assert_eq(conn:dropped(), 0, 'retained view should not use a lossy mailbox')
+	assert_eq(bus:stats().dropped, 0, 'retained view should not affect bus dropped count')
+	assert_eq(conn:stats().retained_watches, 0, 'retained view should not create retained watch feed')
+	assert_eq(conn:stats().retained_views, 1)
+
+	view:close()
+
+	print('Retained view no queue overflow/background fibre test passed!')
+end
+
+--------------------------------------------------------------------------------
 -- Additional origin / provenance tests
 --------------------------------------------------------------------------------
 
@@ -862,6 +1201,44 @@ local function test_retained_replay_preserves_original_origin()
 	rw:unwatch()
 
 	print('Retained replay preserves original origin test passed!')
+end
+
+local function test_retained_view_preserves_original_origin()
+	local bus = Bus.new({ m_wild = '#', s_wild = '+' })
+
+	local source = bus:connect({
+		principal = admin_principal('view-ret-source'),
+		origin_factory = {
+			kind       = 'fabric_import',
+			link_id    = 'link-view-ret',
+			peer_node  = 'peer-view-ret',
+			peer_sid   = 'sid-view-ret',
+			generation = 18,
+		},
+	})
+
+	source:retain({ 'origin', 'viewret' }, 'VR1', {
+		extra = { trace = 'view-retain-trace' },
+	})
+
+	local view = bus:connect():retained_view({ 'origin', 'viewret' })
+	local msg = view:get({ 'origin', 'viewret' })
+
+	assert(msg and msg.payload == 'VR1', 'expected retained view to contain VR1')
+	assert_origin_fields(msg.origin, {
+		kind       = 'fabric_import',
+		link_id    = 'link-view-ret',
+		peer_node  = 'peer-view-ret',
+		peer_sid   = 'sid-view-ret',
+		generation = 18,
+	})
+	assert_eq(msg.origin.extra.trace, 'view-retain-trace')
+	assert_origin_immutable(msg.origin)
+	assert_origin_extra_immutable(msg.origin)
+
+	view:close()
+
+	print('Retained view preserves original origin test passed!')
 end
 
 local function test_unretain_event_origin_metadata()
@@ -1142,6 +1519,8 @@ local function test_request_done_state_for_fail_and_abandon()
 	local req = Bus.Request and Bus.Request or error('Bus.Request missing')
 	local origin = setmetatable({}, { __index = { kind = 'local' }, __newindex = function () error('immutable') end })
 	local r = req.__index and nil
+	assert(origin ~= nil and r == nil)
+
 	-- Use the real command plane instead of constructing Request internals directly.
 	local bus    = Bus.new({ m_wild = '#', s_wild = '+' })
 	local server = bus:connect()
@@ -1681,9 +2060,15 @@ local function test_authz_denies_without_admin_role()
 	assert(tostring(err5):match('permission denied'), tostring(err5))
 
 	local ok6, err6 = pcall(function()
+		conn_viewer:retained_view({ 'authz', 'deny', 'view' })
+	end)
+	assert(not ok6, 'expected retained_view without admin role to be denied')
+	assert(tostring(err6):match('permission denied'), tostring(err6))
+
+	local ok7, err7 = pcall(function()
 		conn_viewer:derive()
 	end)
-	assert(ok6, 'expected derive itself not to be authoriser-gated: ' .. tostring(err6))
+	assert(ok7, 'expected derive itself not to be authoriser-gated: ' .. tostring(err7))
 
 	print('Authz deny test passed!')
 end
@@ -1752,6 +2137,15 @@ local function test_authz_admin_allows_and_records_actions()
 
 	rw:unwatch()
 
+	-- retained_view is authorised as watch_retained.
+	local view = conn1:retained_view({ 'authz', 'view' })
+	conn1:retain({ 'authz', 'view' }, 'VW')
+	do
+		local msg = view:get({ 'authz', 'view' })
+		assert(msg and msg.payload == 'VW', 'expected authorised retained view to observe retained state')
+	end
+	view:close()
+
 	-- bind + call
 	local rpc_ep = conn2:bind({ 'authz', 'rpc' }, { queue_len = 1 })
 	fibers.spawn(function()
@@ -1808,9 +2202,21 @@ fibers.run(function ()
 	test_retained_watch_replay_done_empty()
 	test_retained_watch_replay_overflow_closes_watch()
 
+	test_feed_distinct_metatables_and_method_guards()
+	test_feed_closed_op_reason()
+
+	test_retained_view_empty_replay_ready()
+	test_retained_view_replay_snapshot_and_live_changes()
+	test_retained_view_wildcards_and_literal_tokens()
+	test_retained_view_changed_op_integer_validation()
+	test_retained_view_close_and_disconnect()
+	test_retained_view_scope_cleanup()
+	test_retained_view_no_queue_overflow_or_background_fibre()
+
 	test_origin_factory_function_and_extra_on_publish()
 	test_origin_conn_ids_distinct_between_connections()
 	test_retained_replay_preserves_original_origin()
+	test_retained_view_preserves_original_origin()
 	test_unretain_event_origin_metadata()
 	test_call_request_origin_factory_and_extra()
 

--- a/tests/test.lua
+++ b/tests/test.lua
@@ -38,14 +38,6 @@ local function topic_str(topic)
 	return table.concat(parts, '/')
 end
 
-local function table_count(t)
-	local n = 0
-	for _ in pairs(t or {}) do
-		n = n + 1
-	end
-	return n
-end
-
 local function assert_local_origin(origin, principal)
 	assert(type(origin) == 'table', 'expected origin table')
 	assert_eq(origin.kind, 'local', 'expected local origin kind')
@@ -83,7 +75,7 @@ local function assert_origin_extra_immutable(origin)
 	assert(not ok, 'expected origin.extra to be immutable')
 end
 
--- A standard “deadline arm”: returns (nil, 'timeout').
+-- A standard deadline arm: returns (nil, 'timeout').
 local function timeout_op(dt)
 	return Sleep.sleep_op(dt):wrap(function ()
 		return nil, 'timeout'
@@ -97,7 +89,7 @@ end
 
 local function wait_view_changed(view, last_seen, label)
 	local which, version, err = select_named({
-		changed  = view:changed_op(last_seen):wrap(function (v) return v, nil end),
+		changed  = view:changed_op(last_seen),
 		deadline = timeout_op(LONG_TMO),
 	})
 
@@ -105,6 +97,17 @@ local function wait_view_changed(view, last_seen, label)
 	assert(err == nil, tostring(err))
 	assert(type(version) == 'number', 'expected numeric retained view version')
 	return version
+end
+
+local function wait_view_closed(view, last_seen, expected_reason, label)
+	local which, version, err = select_named({
+		changed  = view:changed_op(last_seen),
+		deadline = timeout_op(LONG_TMO),
+	})
+
+	assert_eq(which, 'changed', label or 'expected retained view close to wake changed_op')
+	assert(version == nil, 'expected nil version when retained view is closed')
+	assert_eq(err, expected_reason or 'closed')
 end
 
 --------------------------------------------------------------------------------
@@ -153,7 +156,7 @@ local function new_admin_only_authoriser(log)
 end
 
 --------------------------------------------------------------------------------
--- Test Simple PubSub (direct op performance)
+-- Test Simple PubSub
 --------------------------------------------------------------------------------
 
 local function test_simple()
@@ -172,7 +175,7 @@ local function test_simple()
 end
 
 --------------------------------------------------------------------------------
--- Test Selecting Across Subscriptions (fan-in / select)
+-- Test Selecting Across Subscriptions
 --------------------------------------------------------------------------------
 
 local function test_select_across_subs()
@@ -197,7 +200,7 @@ local function test_select_across_subs()
 end
 
 --------------------------------------------------------------------------------
--- Test Absence as a Race (no baked-in timeouts)
+-- Test Absence as a Race
 --------------------------------------------------------------------------------
 
 local function test_absence_via_deadline()
@@ -218,7 +221,7 @@ local function test_absence_via_deadline()
 end
 
 --------------------------------------------------------------------------------
--- Test Graceful Consumer Stop (external control op + acknowledgements)
+-- Test Graceful Consumer Stop
 --------------------------------------------------------------------------------
 
 local function test_graceful_stop_signal()
@@ -228,7 +231,6 @@ local function test_graceful_stop_signal()
 
 	local stop = Cond.new()
 
-	-- Consumer acks each processed message so the test can be deterministic.
 	local ack  = Channel.new(10)
 	local done = Channel.new(1)
 
@@ -248,19 +250,16 @@ local function test_graceful_stop_signal()
 			assert(err == nil, tostring(err))
 			out[#out + 1] = msg.payload
 
-			-- Ack should not block in the test.
 			ack:put(msg.payload)
 		end
 
 		done:put(out)
 	end)
 
-	-- Publish three messages.
 	conn:publish({ 'loop', 'topic' }, 'one')
 	conn:publish({ 'loop', 'topic' }, 'two')
 	conn:publish({ 'loop', 'topic' }, 'three')
 
-	-- Wait for three acks (each is itself a race).
 	local expect = { 'one', 'two', 'three' }
 	for i = 1, #expect do
 		local which, v, err = select_named({
@@ -272,7 +271,6 @@ local function test_graceful_stop_signal()
 		assert(v == expect[i], ('expected ack %q, got %q'):format(tostring(expect[i]), tostring(v)))
 	end
 
-	-- Now request stop, and ensure the consumer terminates promptly.
 	stop:signal()
 
 	local which, out, err = select_named({
@@ -304,7 +302,6 @@ local function test_conn_clean()
 
 	conn:disconnect()
 
-	-- Subscription should close promptly with reason "disconnected".
 	local which, m2, e2 = select_named({
 		msg      = sub:recv_op(),
 		deadline = timeout_op(LONG_TMO),
@@ -313,7 +310,6 @@ local function test_conn_clean()
 	assert(m2 == nil)
 	assert(e2 == 'disconnected', ('expected disconnected, got %s'):format(tostring(e2)))
 
-	-- Disconnected connections must not be usable.
 	local ok = pcall(function ()
 		conn:publish({ 'cleanup', 'topic' }, 'should error')
 	end)
@@ -450,7 +446,6 @@ local function test_retained_watch_replay_and_live_changes()
 		assert_local_origin(ev.origin)
 	end
 
-	-- Ordinary publish should not appear on retained watch feeds.
 	conn:publish({ 'watch', 'c' }, 'PUBONLY')
 
 	do
@@ -808,7 +803,7 @@ local function test_retained_view_empty_replay_ready()
 
 	do
 		local which, version, err = select_named({
-			changed  = view:changed_op(view:version()):wrap(function (v) return v, nil end),
+			changed  = view:changed_op(view:version()),
 			deadline = timeout_op(TMO),
 		})
 		assert_eq(which, 'deadline')
@@ -848,7 +843,7 @@ local function test_retained_view_replay_snapshot_and_live_changes()
 	assert(ma and ma.payload == 'A1', 'expected replayed A1')
 	assert(mb and mb.payload == 'B1', 'expected replayed B1')
 	assert(mx == nil, 'expected non-matching retained topic to be absent')
-	assert_eq(table_count(view:snapshot()), 2, 'expected two retained view items')
+	assert_eq(#view:snapshot(), 2, 'expected two retained view items')
 	assert(view:version() >= 2, 'expected replay to advance version')
 
 	local last = view:version()
@@ -866,7 +861,7 @@ local function test_retained_view_replay_snapshot_and_live_changes()
 
 	do
 		local which, version, err = select_named({
-			changed  = view:changed_op(last):wrap(function (v) return v, nil end),
+			changed  = view:changed_op(last),
 			deadline = timeout_op(TMO),
 		})
 		assert_eq(which, 'deadline')
@@ -877,7 +872,7 @@ local function test_retained_view_replay_snapshot_and_live_changes()
 	last = wait_view_changed(view, last, 'expected unretain to change view')
 
 	assert(view:get({ 'view', 'state', 'b' }) == nil, 'expected b to be removed')
-	assert_eq(table_count(view:items()), 1, 'expected one retained view item after unretain')
+	assert_eq(#view:items(), 1, 'expected one retained view item after unretain')
 
 	view:close()
 
@@ -896,15 +891,15 @@ local function test_retained_view_wildcards_and_literal_tokens()
 	local view_lit_plus = conn:retained_view({ 'viewlit', 'metrics', Bus.literal('+') })
 	local view_lit_hash_mid = conn:retained_view({ 'viewlit', 'lit', Bus.literal('#'), 'x' })
 
-	assert_eq(table_count(view_wild:snapshot()), 2, 'wild view should include PLUS and ABC')
+	assert_eq(#view_wild:snapshot(), 2, 'wild view should include PLUS and ABC')
 	assert(view_wild:get({ 'viewlit', 'metrics', '+' }).payload == 'PLUS')
 	assert(view_wild:get({ 'viewlit', 'metrics', 'abc' }).payload == 'ABC')
 
-	assert_eq(table_count(view_lit_plus:snapshot()), 1, 'literal plus view should include only literal plus')
+	assert_eq(#view_lit_plus:snapshot(), 1, 'literal plus view should include only literal plus')
 	assert(view_lit_plus:get({ 'viewlit', 'metrics', '+' }).payload == 'PLUS')
 	assert(view_lit_plus:get({ 'viewlit', 'metrics', 'abc' }) == nil)
 
-	assert_eq(table_count(view_lit_hash_mid:snapshot()), 1, 'literal hash view should include only literal hash mid-token')
+	assert_eq(#view_lit_hash_mid:snapshot(), 1, 'literal hash view should include only literal hash mid-token')
 	assert(view_lit_hash_mid:get({ 'viewlit', 'lit', '#', 'x' }).payload == 'HASHMID')
 
 	view_wild:close()
@@ -953,15 +948,7 @@ local function test_retained_view_close_and_disconnect()
 	local last = view:version()
 	view:close()
 
-	do
-		local which, version, err = select_named({
-			changed  = view:changed_op(last):wrap(function (v) return v, nil end),
-			deadline = timeout_op(LONG_TMO),
-		})
-		assert_eq(which, 'changed')
-		assert(err == nil)
-		assert(version > last, 'expected close to advance view version')
-	end
+	wait_view_closed(view, last, 'closed')
 
 	do
 		local reason = fibers.perform(view:closed_op())
@@ -975,7 +962,10 @@ local function test_retained_view_close_and_disconnect()
 	local view2 = conn2:retained_view({ 'view', 'disconnect' })
 	assert_eq(bus:stats().retained_views, 1)
 
+	local last2 = view2:version()
 	conn2:disconnect()
+
+	wait_view_closed(view2, last2, 'disconnected')
 
 	do
 		local reason = fibers.perform(view2:closed_op())
@@ -1018,7 +1008,7 @@ local function test_retained_view_no_queue_overflow_or_background_fibre()
 		full      = 'reject_newest',
 	})
 
-	assert_eq(table_count(view:snapshot()), 20, 'retained view should materialise all matching retained state')
+	assert_eq(#view:snapshot(), 20, 'retained view should materialise all matching retained state')
 	assert_eq(conn:dropped(), 0, 'retained view should not use a lossy mailbox')
 	assert_eq(bus:stats().dropped, 0, 'retained view should not affect bus dropped count')
 	assert_eq(conn:stats().retained_watches, 0, 'retained view should not create retained watch feed')
@@ -1459,7 +1449,7 @@ local function test_derive_connection_scope_cleanup()
 	local outer = bus:connect()
 	local sub = outer:subscribe({ 'derive', 'scope' }, { queue_len = 4 })
 
-	local st, rep = fibers.run_scope(function (s)
+	local st, rep = fibers.run_scope(function ()
 		local parent = bus:connect({ principal = admin_principal('scoped-parent') })
 		local child  = parent:derive()
 		child:publish({ 'derive', 'scope' }, 'before')
@@ -1521,7 +1511,6 @@ local function test_request_done_state_for_fail_and_abandon()
 	local r = req.__index and nil
 	assert(origin ~= nil and r == nil)
 
-	-- Use the real command plane instead of constructing Request internals directly.
 	local bus    = Bus.new({ m_wild = '#', s_wild = '+' })
 	local server = bus:connect()
 	local client = bus:connect()
@@ -1870,7 +1859,6 @@ local function test_laneB_concrete_topic_enforcement_and_literal_ok()
 	print('Lane B concrete-topic enforcement + literal wrapper test passed!')
 end
 
--- Explicit modality check: publish() does not reach endpoints; call() does.
 local function test_laneB_endpoint_not_reached_by_publish()
 	local bus    = Bus.new({ m_wild = '#', s_wild = '+' })
 	local server = bus:connect()
@@ -1992,7 +1980,7 @@ local function test_laneB_call_fail_propagates_error()
 end
 
 --------------------------------------------------------------------------------
--- Scope cancellation as control flow (no local exception handling)
+-- Scope cancellation as control flow
 --------------------------------------------------------------------------------
 
 local function test_scope_cancellation_terminates_waits()
@@ -2089,7 +2077,6 @@ local function test_authz_admin_allows_and_records_actions()
 
 	assert(conn1:principal() == admin1, 'expected principal() to return supplied principal')
 
-	-- subscribe + publish
 	local sub = conn1:subscribe({ 'authz', 'pubsub' })
 	conn1:publish({ 'authz', 'pubsub' }, 'hello')
 	do
@@ -2098,7 +2085,6 @@ local function test_authz_admin_allows_and_records_actions()
 		assert_local_origin(msg.origin, admin1)
 	end
 
-	-- retain + unretain
 	conn1:retain({ 'authz', 'retained' }, 'R')
 	local sub_ret = conn1:subscribe({ 'authz', 'retained' })
 	do
@@ -2116,10 +2102,8 @@ local function test_authz_admin_allows_and_records_actions()
 		assert_timeout(msg, err)
 	end
 
-	-- watch_retained
 	local rw = conn1:watch_retained({ 'authz', 'watch' }, { replay = true })
 
-	-- replay=true always emits a replay_done marker, even when the initial set is empty.
 	do
 		local ev, err = fibers.perform(rw:recv_op())
 		assert(err == nil and ev, tostring(err))
@@ -2137,7 +2121,6 @@ local function test_authz_admin_allows_and_records_actions()
 
 	rw:unwatch()
 
-	-- retained_view is authorised as watch_retained.
 	local view = conn1:retained_view({ 'authz', 'view' })
 	conn1:retain({ 'authz', 'view' }, 'VW')
 	do
@@ -2146,7 +2129,6 @@ local function test_authz_admin_allows_and_records_actions()
 	end
 	view:close()
 
-	-- bind + call
 	local rpc_ep = conn2:bind({ 'authz', 'rpc' }, { queue_len = 1 })
 	fibers.spawn(function()
 		local req, err = rpc_ep:recv()


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [x] 🍕 Feature
* [x] 📝 Documentation Update
* [x] 🧑‍💻 Code Refactor
* [x] ✅ Test

## Description

Refactors `bus` around a smaller, clearer public API, adds bus-owned immutable origin metadata to delivered objects, makes retained replay completion explicit, and adds retained materialised views for event-driven retained-state observation.

This change narrows the bus to two public planes:

* **state/event plane**: `publish`, `retain`, `unretain`, `subscribe`, `watch_retained`, `retained_view`
* **command plane**: `bind`, `call`

### Main changes

* removes the public request/reply helpers built on reply topics:

  * `request_sub`
  * `request_once_op`
  * `publish_one`

* changes endpoint delivery from ordinary `Message` objects to native `Request` objects with:

  * `reply(...)`
  * `fail(...)`
  * `abandon(...)`
  * `done()`
  * `wait_reply_op()`

* adds immutable `origin` metadata to:

  * subscription messages
  * retained-watch events
  * retained-view messages
  * endpoint requests

* makes provenance bus-owned:

  * trusted top-level origin fields come from the connection’s `origin_factory` / `origin_base`
  * callers may only attach `opts.extra`, exposed as immutable `origin.extra`

* adds retained-watch `replay_done` events so consumers can tell when initial retained replay has completed

* preserves retained-message origin across retained replay and retained materialised views

* adds retained materialised views:

  * `conn:retained_view(topic_pattern)`
  * `view:version()`
  * `view:changed_op(last_seen)`
  * `view:get(topic)`
  * `view:snapshot()`
  * `view:items()`
  * `view:close()`
  * `view:closed_op()`

* makes retained-view snapshots array-based rather than exposing the internal topic-key map

* makes `RetainedView:changed_op(last_seen)` close-aware, returning either:

  * `new_version, nil` when the view changes
  * `nil, reason` when the view closes

* adds generic queued-feed helpers:

  * `feed:close()`
  * `feed:closed_op()`
  * `feed:kind()`

* adds / updates tests for:

  * revised bus API
  * request/reply endpoint behaviour
  * origin propagation and immutability
  * retained replay completion and replay overflow behaviour
  * retained materialised views
  * close-aware retained-view change waiting
  * retained-view snapshot shape
  * authz with principals

* updates README / API documentation to reflect the revised model

### Behavioural notes

* endpoint calls remain bounded and timeout-driven
* ordinary publish traffic does **not** reach bound endpoints; only `call(...)` does
* retained-watch replay can now end in one of two explicit ways:

  * `replay_done`
  * watch closure with `replay_overflow` if the replay cannot fit in the configured queue

* retained views are not event logs and do not use queues
* retained views expose current retained truth through a versioned, materialised snapshot
* retained-view changes may be coalesced between observations
* retained-view snapshots are arrays of `Message` objects, not maps keyed by internal topic strings

## Related Issues, Tickets & Documents

N/A

## Screenshots/Recordings

N/A

## Manual test

* [x] 👍 yes

## Manual test description

Ran the bus test suite and updated it for the revised API.

Verified:

* ordinary publish / subscribe
* retained message replay and unretain
* retained-watch replay, `replay_done`, and replay overflow closure
* retained materialised view initialisation from retained state
* retained materialised view updates on retain and unretain
* retained-view `changed_op(last_seen)` change and close behaviour
* retained-view array snapshot shape
* endpoint bind / call / reply / fail / timeout behaviour
* queued feed closure behaviour
* origin propagation, trusted origin fields, and immutability of `origin` / `origin.extra`
* authz behaviour with principals

## Added tests?

* [x] 👍 yes

## Added to documentation?

* [x] 📜 README.md

## [optional] Are there any post-deployment tasks we need to perform?

Update internal callers that still use removed helpers (`request_sub`, `request_once_op`, `publish_one`) to the endpoint-based `bind` / `call` model, and update any code that assumed reply-topic semantics to use `Request` objects instead.

Where tests or services currently use retained watches only to assert current retained truth, consider moving them to `retained_view(...)` so they can be more event-driven and less dependent on queue timing.