### PR TITLE
disconnection cleans up after itself

### DIFF
--- a/src/bus.lua
+++ b/src/bus.lua
@@ -1124,6 +1124,7 @@ end
 ---@field _eps table<Endpoint, boolean>
 ---@field _rws table<RetainedWatch, boolean>
 ---@field _views table<RetainedView, boolean>
+---@field _detach_finaliser function|nil
 ---@field _disconnected boolean
 ---@field _conn_id string
 ---@field _origin_factory table|fun():table
@@ -1146,6 +1147,7 @@ local function new_connection(bus, principal, q_length, full, origin_factory)
 		_eps            = {},
 		_rws            = {},
 		_views          = {},
+		_detach_finaliser = nil,
 		_disconnected   = false,
 		_conn_id        = tostring(uuid.new()),
 		_origin_factory = origin_factory or {},
@@ -1484,6 +1486,7 @@ end
 function Connection:disconnect()
 	if self._disconnected then return true end
 
+	clear_finaliser(self)
 	self._disconnected = true
 
 	local bus = self._bus
@@ -1556,7 +1559,8 @@ function Bus:connect(opts)
 
 	self._conns[conn] = true
 
-	s:finally(function ()
+	conn._detach_finaliser = s:finally(function ()
+		conn._detach_finaliser = nil
 		conn:disconnect()
 	end)
 

--- a/tests/test.lua
+++ b/tests/test.lua
@@ -318,6 +318,35 @@ local function test_conn_clean()
 	print('Connection cleanup test passed!')
 end
 
+
+--------------------------------------------------------------------------------
+-- Test Connection Finaliser Detachment on Explicit Disconnect
+--------------------------------------------------------------------------------
+
+-- Regression test for explicit Connection:disconnect(). Bus:connect()
+-- installs a scope finaliser so that connections are disconnected on scope
+-- exit. Explicit disconnect must detach that finaliser immediately; otherwise
+-- long-lived scopes retain one finaliser closure, and therefore one connection
+-- object, for every connection ever opened and disconnected.
+local function test_disconnect_detaches_connection_finaliser()
+	local bus = Bus.new({ m_wild = '#', s_wild = '+' })
+	local scope = Scope.current()
+	local base = scope._finalisers:length()
+
+	for _ = 1, 1000 do
+		local conn = bus:connect()
+		assert_eq(scope._finalisers:length(), base + 1, 'connect should install one finaliser')
+		conn:disconnect()
+		assert_eq(scope._finalisers:length(), base, 'disconnect should detach its finaliser')
+	end
+
+	collectgarbage('collect')
+	assert_eq(scope._finalisers:length(), base, 'finaliser list should remain at baseline after GC')
+	assert_eq(bus:stats().connections, 0, 'all connections should be removed from bus stats')
+
+	print('Connection finaliser detachment test passed!')
+end
+
 --------------------------------------------------------------------------------
 -- Retained Message Tests
 --------------------------------------------------------------------------------
@@ -2352,6 +2381,7 @@ fibers.run(function ()
 	test_absence_via_deadline()
 	test_graceful_stop_signal()
 	test_conn_clean()
+	test_disconnect_detaches_connection_finaliser()
 
 	test_unsubscribe()
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [x] 🐛 Bug Fix
* [x] ✅ Test

## Description

Fixes retention of connection objects after explicit `Connection:disconnect()`.

Previously, `Bus:connect()` registered a scope finaliser that called `conn:disconnect()`, but the detach function for that finaliser was not stored on the connection. If a connection was explicitly disconnected inside a long-lived scope, the bus removed the connection, but the scope still retained the finaliser closure until scope exit. That closure retained the connection object unnecessarily.

Changes:

* Store the connection scope-finaliser detach function on the connection.
* Clear the finaliser when `Connection:disconnect()` is called explicitly.
* Clear the stored detach handle when the scope finaliser itself runs.
* Add an inline regression test covering repeated connect/disconnect cycles in one long-lived scope.

## Manual test

* [x] 👍 yes

## Manual test description

Ran the single-file bus test with `luajit`:

```text
luajit tests/test.lua
```

All passed.

## Added tests?

* [x] 👍 yes

## Added to documentation?

* [x] 🙅 no documentation needed
